### PR TITLE
Force project name in env-example

### DIFF
--- a/env-example
+++ b/env-example
@@ -1,3 +1,4 @@
 # Copy this to .env and modify to give docker-compose preset environment vars
 APP_URL=http://localhost
 NCA_NEWS_WEBROOT=https://oregonnews.uoregon.edu
+COMPOSE_PROJECT_NAME=nca


### PR DESCRIPTION
This can help when checking out the project into the default directory,
or renaming the directory, as the documented `docker-compose` containers
will be consistent