### PR TITLE
jobs: don't wrap db.Job

### DIFF
--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -183,15 +183,15 @@ func retryJob(idString string) {
 		return
 	}
 	var failStatus = jobs.JobStatusFailed
-	if j.Status != string(failStatus) {
-		logger.Errorf("Cannot requeue job id %d: status is %s (it must be %s to requeue)", id, j.Status, failStatus)
+	if j.DBJob().Status != string(failStatus) {
+		logger.Errorf("Cannot requeue job id %d: status is %s (it must be %s to requeue)", id, j.DBJob().Status, failStatus)
 		return
 	}
 
-	logger.Infof("Requeuing job %d", j.ID)
+	logger.Infof("Requeuing job %d", j.DBJob().ID)
 	var err = j.Requeue()
 	if err != nil {
-		logger.Errorf("Unable to requeue job %d: %s", j.ID, err)
+		logger.Errorf("Unable to requeue job %d: %s", j.DBJob().ID, err)
 	}
 }
 

--- a/src/jobs/batch_bagit.go
+++ b/src/jobs/batch_bagit.go
@@ -14,10 +14,10 @@ type WriteBagitManifest struct {
 // Process implements Processor, writing out the data manifest, bagit.txt, and
 // the tag manifest
 func (j *WriteBagitManifest) Process(c *config.Config) bool {
-	var b = bagit.New(j.Location)
+	var b = bagit.New(j.db.Location)
 	var err = b.WriteTagFiles()
 	if err != nil {
-		j.Logger.Errorf("Unable to write bagit tag files for %q: %s", j.Location, err)
+		j.Logger.Errorf("Unable to write bagit tag files for %q: %s", j.db.Location, err)
 		return false
 	}
 

--- a/src/jobs/batch_job.go
+++ b/src/jobs/batch_job.go
@@ -40,8 +40,8 @@ func nilWorkflowCB() {
 // "ExtraData" is set.  updateWorkflowCB is then called, and the batch data
 // saved back to the database.
 func (j *BatchJob) UpdateWorkflow() {
-	if j.ExtraData != "" {
-		j.DBBatch.Status = j.ExtraData
+	if j.db.ExtraData != "" {
+		j.DBBatch.Status = j.db.ExtraData
 	}
 
 	j.updateWorkflowCB()

--- a/src/jobs/derivatives.go
+++ b/src/jobs/derivatives.go
@@ -68,7 +68,7 @@ func (md *MakeDerivatives) Process(c *config.Config) bool {
 
 // findPDFs builds the list of Alto and JP2 derivative sources
 func (md *MakeDerivatives) findPDFs() (ok bool) {
-	var pdfs, err = fileutil.FindIf(md.Location, func(i os.FileInfo) bool {
+	var pdfs, err = fileutil.FindIf(md.db.Location, func(i os.FileInfo) bool {
 		return pdfFilenameRegex.MatchString(i.Name())
 	})
 
@@ -94,7 +94,7 @@ func (md *MakeDerivatives) findPDFs() (ok bool) {
 // _findTIFFs looks for any TIFF files in the issue directory.  This is only
 // called for scanned issues, so there *must* be TIFFs or this is a failure.
 func (md *MakeDerivatives) _findTIFFs() (ok bool) {
-	var tiffs, err = fileutil.FindIf(md.Location, func(i os.FileInfo) bool {
+	var tiffs, err = fileutil.FindIf(md.db.Location, func(i os.FileInfo) bool {
 		return tiffFilenameRegex.MatchString(i.Name())
 	})
 
@@ -121,7 +121,7 @@ func (md *MakeDerivatives) _findTIFFs() (ok bool) {
 // checks are redundant, but it's clear that with the complexity of our
 // process, more failsafes are better than fewer.
 func (md *MakeDerivatives) validateSourceFiles() (ok bool) {
-	var infos, err = fileutil.ReaddirSorted(md.Location)
+	var infos, err = fileutil.ReaddirSorted(md.db.Location)
 	if err != nil {
 		md.Logger.Errorf("Unable to scan all files: %s", err)
 		return false

--- a/src/jobs/issue_job.go
+++ b/src/jobs/issue_job.go
@@ -61,7 +61,7 @@ func (ij *IssueJob) WIPDir() string {
 // then the issue job is saved.  At this point, however, the job is complete,
 // so all we can do is loudly log failures.
 func (ij *IssueJob) UpdateWorkflow() {
-	var ws = schema.WorkflowStep(ij.ExtraData)
+	var ws = schema.WorkflowStep(ij.db.ExtraData)
 	if ws != schema.WSNil {
 		ij.DBIssue.WorkflowStep = ws
 	}

--- a/src/jobs/job.go
+++ b/src/jobs/job.go
@@ -31,13 +31,13 @@ type Processor interface {
 // Job wraps the DB job data and provides business logic for things like
 // logging to the database
 type Job struct {
-	*db.Job
+	db     *db.Job
 	Logger *logger.Logger
 }
 
 // NewJob wraps the given db.Job and sets up a logger
 func NewJob(dbj *db.Job) *Job {
-	var j = &Job{Job: dbj}
+	var j = &Job{db: dbj}
 	j.Logger = &logger.Logger{Loggable: &jobLogger{Job: j, AppName: filepath.Base(os.Args[0])}}
 	return j
 }
@@ -55,9 +55,9 @@ func Find(id int) *Job {
 	return NewJob(dbJob)
 }
 
-// DBJob returns the database job
+// DBJob implements job.Processor, returning the low-level database structure
 func (j *Job) DBJob() *db.Job {
-	return j.Job
+	return j.db
 }
 
 // RunWhileTrue simplifies the common operation processors deal with when
@@ -79,20 +79,20 @@ func (j *Job) Requeue() error {
 	op.BeginTransaction()
 
 	var clone = &db.Job{
-		Type:       j.Type,
-		ObjectID:   j.ObjectID,
-		ObjectType: j.ObjectType,
-		Location:   j.Location,
+		Type:       j.db.Type,
+		ObjectID:   j.db.ObjectID,
+		ObjectType: j.db.ObjectType,
+		Location:   j.db.Location,
 		Status:     string(JobStatusPending),
-		RunAt:      j.RunAt,
-		ExtraData:  j.ExtraData,
-		QueueJobID: j.QueueJobID,
+		RunAt:      j.db.RunAt,
+		ExtraData:  j.db.ExtraData,
+		QueueJobID: j.db.QueueJobID,
 	}
 
 	clone.SaveOp(op)
 
-	j.Status = string(JobStatusFailedDone)
-	j.SaveOp(op)
+	j.db.Status = string(JobStatusFailedDone)
+	j.db.SaveOp(op)
 
 	op.EndTransaction()
 	return op.Err()
@@ -110,7 +110,7 @@ type jobLogger struct {
 func (l *jobLogger) Log(level logger.LogLevel, message string) {
 	var timeString = time.Now().Format(logger.TimeFormat)
 	var msg = fmt.Sprintf("%s - %s - %s - [job %s:%d] %s\n",
-		timeString, l.AppName, level.String(), l.Job.Type, l.Job.ID, message)
+		timeString, l.AppName, level.String(), l.db.Type, l.db.ID, message)
 	var _, err = os.Stderr.WriteString(msg)
 	if err != nil {
 		_, err = fmt.Printf("ERROR: unable to write log message %q to STDERR: %s", msg, err)
@@ -120,7 +120,7 @@ func (l *jobLogger) Log(level logger.LogLevel, message string) {
 		}
 	}
 
-	err = l.Job.WriteLog(level.String(), message)
+	err = l.db.WriteLog(level.String(), message)
 	if err != nil {
 		logger.Criticalf("Unable to write log message: %s", err)
 		return

--- a/src/jobs/make_batch_xml.go
+++ b/src/jobs/make_batch_xml.go
@@ -19,7 +19,7 @@ func (j *MakeBatchXML) Process(c *config.Config) bool {
 
 	// Set up variables
 	var templatePath = c.BatchXMLTemplatePath
-	var outputXMLPath = filepath.Join(j.Location, "data", "batch.xml")
+	var outputXMLPath = filepath.Join(j.db.Location, "data", "batch.xml")
 
 	var issues, err = j.DBBatch.Issues()
 	if err != nil {

--- a/src/jobs/move_batch_to_ready_location.go
+++ b/src/jobs/move_batch_to_ready_location.go
@@ -15,9 +15,9 @@ type MoveBatchToReadyLocation struct {
 // Process implements Processor by renaming the batch directory
 func (j *MoveBatchToReadyLocation) Process(c *config.Config) bool {
 	var newPath = path.Join(c.BatchOutputPath, j.DBBatch.FullName())
-	var err = os.Rename(j.Location, newPath)
+	var err = os.Rename(j.db.Location, newPath)
 	if err != nil {
-		j.Logger.Errorf("Unable to rename WIP batch directory (%q -> %q): %s", j.Location, newPath, err)
+		j.Logger.Errorf("Unable to rename WIP batch directory (%q -> %q): %s", j.db.Location, newPath, err)
 		return false
 	}
 	j.DBBatch.Location = newPath

--- a/src/jobs/move_issue.go
+++ b/src/jobs/move_issue.go
@@ -13,7 +13,7 @@ func moveIssue(ij *IssueJob, path string) bool {
 	var iKey = ij.Issue.Key()
 
 	// Verify new path will work
-	var oldLocation = ij.Location
+	var oldLocation = ij.db.Location
 	var newLocation = filepath.Join(path, ij.Subdir())
 	if !fileutil.MustNotExist(newLocation) {
 		ij.Logger.Errorf("Destination %q already exists for issue %q", newLocation, iKey)

--- a/src/jobs/pagesplit.go
+++ b/src/jobs/pagesplit.go
@@ -100,9 +100,9 @@ func (ps *PageSplit) process() (ok bool) {
 func (ps *PageSplit) createMasterPDF() (ok bool) {
 	ps.Logger.Debugf("Preprocessing with ghostscript")
 
-	var fileinfos, err = fileutil.ReaddirSorted(ps.Location)
+	var fileinfos, err = fileutil.ReaddirSorted(ps.db.Location)
 	if err != nil {
-		ps.Logger.Errorf("Unable to list files in %q: %s", ps.Location, err)
+		ps.Logger.Errorf("Unable to list files in %q: %s", ps.db.Location, err)
 		return false
 	}
 
@@ -112,7 +112,7 @@ func (ps *PageSplit) createMasterPDF() (ok bool) {
 		"-dCompressFonts=true", "-r150", "-sOutputFile=" + ps.FakeMasterFile,
 	}
 	for _, fi := range fileinfos {
-		args = append(args, filepath.Join(ps.Location, fi.Name()))
+		args = append(args, filepath.Join(ps.db.Location, fi.Name()))
 	}
 	return shell.ExecSubgroup(ps.GhostScript, args...)
 }
@@ -203,13 +203,13 @@ func (ps *PageSplit) backupOriginals() (ok bool) {
 		return false
 	}
 
-	err = fileutil.CopyDirectory(ps.Location, ps.MasterBackup)
+	err = fileutil.CopyDirectory(ps.db.Location, ps.MasterBackup)
 	if err != nil {
-		ps.Logger.Criticalf("Unable to copy master file(s) from %q to %q: %s", ps.Location, ps.MasterBackup, err)
+		ps.Logger.Criticalf("Unable to copy master file(s) from %q to %q: %s", ps.db.Location, ps.MasterBackup, err)
 		return false
 	}
 
-	err = os.RemoveAll(ps.Location)
+	err = os.RemoveAll(ps.db.Location)
 	if err != nil {
 		ps.Logger.Criticalf("Unable to remove original files after making master backup: %s", err)
 		return false
@@ -228,9 +228,9 @@ func (ps *PageSplit) moveIssue() (ok bool) {
 		ps.Logger.Criticalf("Unable to move temporary directory %q to %q: %s", ps.TempDir, ps.WIPDir, err)
 		return false
 	}
-	err = os.Rename(ps.WIPDir, ps.Location)
+	err = os.Rename(ps.WIPDir, ps.db.Location)
 	if err != nil {
-		ps.Logger.Criticalf("Unable to move WIP directory %q to %q: %s", ps.WIPDir, ps.Location, err)
+		ps.Logger.Criticalf("Unable to move WIP directory %q to %q: %s", ps.WIPDir, ps.db.Location, err)
 		return false
 	}
 	return true


### PR DESCRIPTION
This "unrolls" the Job type so that instead of acting as if jobs.Job
*is* a db.Job, it simply **contains** a db.Job.  This makes a bit more
sense conceptually, especially in cases where we had to call `job.Job`
to get at the database structure.