### PR TITLE
uploadedissuehandler: lower severity of messages

### DIFF
--- a/src/cmd/server/internal/uploadedissuehandler/schema.go
+++ b/src/cmd/server/internal/uploadedissuehandler/schema.go
@@ -149,7 +149,7 @@ func (i *Issue) decorateFiles(fileList []*uploads.File) {
 func (i *Issue) decoratePriorJobLogs() {
 	var dbi, err = db.FindIssueByKey(i.Key())
 	if err != nil {
-		logger.Errorf("Unable to look up issue for decorating queue messages: %s", err)
+		logger.Warnf("Unable to look up issue for decorating queue messages: %s", err)
 		return
 	}
 	if dbi == nil {


### PR DESCRIPTION
Inability to decorate issues with prior job logs isn't really a failure
mode - it's not great, but it doesn't mean the issue can't be fixed in
the UI or anything

Closes #57 