### PR TITLE
Fix permissions

### DIFF
--- a/src/derivatives/jp2/make_jp2.go
+++ b/src/derivatives/jp2/make_jp2.go
@@ -176,6 +176,10 @@ func (t *Transformer) moveTempJP2() {
 			return
 		}
 	}
+
+	// Make sure the JP2 can be read by non-NCA apps!  The output is very
+	// restricted, likely due to temp file security.
+	os.Chmod(t.OutputJP2, 0644)
 }
 
 // testRate is a simple helper to create a JP2 and then try to read it

--- a/src/jobs/move_issue.go
+++ b/src/jobs/move_issue.go
@@ -40,6 +40,9 @@ func moveIssue(ij *IssueJob, path string) bool {
 	}
 	ij.Issue.Location = newLocation
 
+	// Make sure non-NCA apps can read the new location
+	os.Chmod(newLocation, 0755)
+
 	// The issue has been moved, so a failure updating the record isn't a failure
 	// and can only be logged loudly
 	ij.DBIssue.Location = ij.Issue.Location


### PR DESCRIPTION
After moving files into NCA, and when generating JP2 files, permissions
need to be given to anything that isn't running as the NCA user so that
things like the IIIF server can see images