### PR TITLE
Check filename validation before derivative jobs

### DIFF
--- a/src/jobs/derivatives.go
+++ b/src/jobs/derivatives.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,7 +12,6 @@ import (
 	"github.com/uoregon-libraries/newspaper-curation-app/src/derivatives/jp2"
 )
 
-var allowedFilesRegex = regexp.MustCompile(`(?i:^([0-9]+.(pdf|jp2|xml|tiff?))|[0-9]{10}.xml|master.tar)`)
 var pdfFilenameRegex = regexp.MustCompile(`(?i:^[0-9]+.pdf)`)
 var tiffFilenameRegex = regexp.MustCompile(`(?i:^[0-9]+.tiff?)`)
 
@@ -120,16 +118,15 @@ func (md *MakeDerivatives) _findTIFFs() (ok bool) {
 // checks are redundant, but it's clear that with the complexity of our
 // process, more failsafes are better than fewer.
 func (md *MakeDerivatives) validateSourceFiles() (ok bool) {
-	var infos, err = ioutil.ReadDir(md.DBIssue.Location)
-	if err != nil {
-		md.Logger.Errorf("Unable to scan all files: %s", err)
+	md.Issue.FindFiles()
+	if len(md.Issue.Files) == 0 {
+		md.Logger.Errorf("No files found")
 		return false
 	}
 
-	for _, info := range infos {
-		var n = info.Name()
-		if !allowedFilesRegex.MatchString(n) {
-			md.Logger.Errorf("Unexpected file found: %q", n)
+	for _, f := range md.Issue.Files {
+		if !f.ValidName() {
+			md.Logger.Errorf("Unexpected file found: %q", f.Name)
 			return false
 		}
 	}

--- a/src/schema/schema.go
+++ b/src/schema/schema.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -489,12 +490,20 @@ func (list IssueList) SortByKey() {
 	})
 }
 
+var allowedFilesRegex = regexp.MustCompile(`(?i:^([0-9]+.(pdf|jp2|xml|tiff?))|[0-9]{10}.xml|master.tar)`)
+
 // File just gives fileutil.File a location and issue pointer
 type File struct {
 	*fileutil.File
 	Location string
 	Issue    *Issue
 	Errors   apperr.List
+}
+
+// ValidName just returns whether the filename matches what we allow to exist once
+// something has entered NCA's internal workflow
+func (f *File) ValidName() bool {
+	return allowedFilesRegex.MatchString(f.Name)
 }
 
 // AddError puts err on this file and reports to its issue that one of its

--- a/src/uploads/issue.go
+++ b/src/uploads/issue.go
@@ -3,6 +3,7 @@ package uploads
 import (
 	"time"
 
+	"github.com/uoregon-libraries/newspaper-curation-app/src/apperr"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/config"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/issuewatcher"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
@@ -56,8 +57,24 @@ func (i *Issue) ValidateFast() {
 	if len(i.Title.Errors) > 0 {
 		i.ErrBadTitle()
 	}
-
+	i.validateFilenames()
 	i.CheckDupes(i.scanner.Lookup)
+}
+
+// validateFilenames uses the issue's workflow step to decide what filename
+// patterns are allowed
+func (i *Issue) validateFilenames() {
+	// We only check in-house scans since publisher uploads have to be manually
+	// handled by staff anyway
+	if i.WorkflowStep != schema.WSScan {
+		return
+	}
+
+	for _, f := range i.Files {
+		if !f.ValidName() {
+			f.AddError(apperr.Errorf("invalid filename for scanned issue %q", f.Name))
+		}
+	}
 }
 
 // ValidateAll runs through all upload-queue-specific validations and adds


### PR DESCRIPTION
Adds a check for filenames when queueing scanned issues so they *really*
shouldn't get to the derivative phase with broken filenames.  The
derivative filename check still occurs to ensure extra safety.