### PR TITLE
Fix local dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,5 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - run: go get -u bitbucket.org/liamstask/goose/cmd/goose
       - run: go get -u golang.org/x/lint/golint
+      - run: go get -u golang.org/x/tools/cmd/goimports
       - run: make deps validate test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ Brief description, if necessary
 ### Migration
 -->
 
+## v3.7.2
+
+Local dev fixes
+
+### Fixed
+
+- Docker builds mostly work again
+  - You currently cannot use a built docker image as a standalone entity; you
+    have to use docker-compose and mount in local binaries.  This will get a
+    github issue.
+- Builds rely on goimports instead of gofmt
+  - This fixes local development when using versioned go (i.e., when you pull
+    down a new version via `go get golang.org/dl/go1.X.Y`)
+
 ## v3.7.1
 
 Deploys work again

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	golint src/...
 
 format:
-	find src/ -name "*.go" | xargs gofmt -l -w -s
+	find src/ -name "*.go" | xargs goimports -l -w -s
 
 test:
 	go test ./src/...

--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -58,6 +58,7 @@ ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
 # Golang dependencies
 RUN go get github.com/pressly/goose/cmd/goose
 RUN go get -u golang.org/x/lint/golint
+RUN go get -u golang.org/x/tools/cmd/goimports
 
 WORKDIR /usr/local/src/nca
 

--- a/docker/wait_for_database
+++ b/docker/wait_for_database
@@ -2,7 +2,7 @@
 MAX_TRIES=15
 TRIES=0
 while true; do
-  mysqladmin status -uroot -hdb p123456
+  mysqladmin status -uroot -hdb -p123456
   st=$?
   if [[ $st == 0 ]]; then
     exit 0

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,13 @@ github.com/go-sql-driver/mysql v1.3.0 h1:pgwjLi/dvffoP9aabwkT3AKpXQM93QARkjFhDDq
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.1.3 h1:uXoZdcdA5XdXF3QzuSlheVRUvjl+1rKY7zBXL68L9RU=
 github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -9,14 +9,14 @@ err() {
 }
 
 IFS=''
-unformatted=$(find src/ -name "*.go" | xargs gofmt -l -s)
+unformatted=$(find src/ -name "*.go" | xargs goimports -l)
 linter=$(golint src/...)
 vet=$(go vet -printfuncs Debugf,Infof,Warnf,Errorf,Criticalf,Fatalf ./src/...  2>&1 || true)
 
 result=0
 
 if [[ $unformatted != "" ]]; then
-  err "gofmt reports issues:"
+  err "goimports reports issues:"
   err "---------------------"
   err $unformatted
   result=1


### PR DESCRIPTION
Closes #135 and another local dev problem related to using `go get golang.org/dl/go1.X.Y` rather than a system-installed Go or a download of a complete Go binary release tarball.