### PR TITLE
Replace SFTPgo JWT auth with admin API key auth

### DIFF
--- a/changelogs/2022-11-28-sftpgo-api-key-auth.md
+++ b/changelogs/2022-11-28-sftpgo-api-key-auth.md
@@ -1,0 +1,13 @@
+### Added
+- Bash scripts added to `sftpgo/` to manage SFTPGo API keys
+
+### Changed
+- SFTPGo integration now uses an admin API key for auth rather than short term
+  tokens
+
+### Migration
+- If using SFTPGo integration, `settings` now requires `SFTPGO_ADMIN_API_KEY`
+  and drops `SFTPGO_ADMIN_LOGIN` and `SFTPGO_ADMIN_PASSWORD`. Copy the relevant
+  section from `settings-example` and run `sftpgo/get_admin_api_key.sh` to issue
+  an admin API key and automatically store it in `settings`.
+

--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -45,6 +45,7 @@ RUN dnf install -y GraphicsMagick ghostscript
 RUN dnf install -y tar
 RUN dnf install -y git
 RUN dnf install -y mariadb
+RUN dnf install -y jq
 
 # Install Go
 RUN curl https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz >/tmp/go.tgz
@@ -79,6 +80,7 @@ RUN cp -r ./bin /usr/local/nca/bin
 # vendored sources, sensitive settings, etc.; we want to make sure this
 # dockerfile stands on its own
 COPY ./db/migrations /usr/local/nca/db/migrations
+COPY ./sftpgo/*.sh /usr/local/nca/sftpgo/
 COPY ./static /usr/local/nca/static
 COPY ./templates /usr/local/nca/templates
 COPY ./settings-example /usr/local/nca/settings

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ lockfile=/mnt/news/goose-running
 source settings && flock $lockfile -c "goose -dir ./db/migrations mysql '$DB_USER:$DB_PASSWORD@tcp(db:3306)/$DB_DATABASE' up"
 
 echo "Get SFTPgo admin API key and store in NCA settings file"
-SETTINGS_PATH=settings SFTPGO_ADMIN_PASSWORD=password sftpgo/get_admin_api_key.sh
+SETTINGS_PATH=settings SFTPGO_ADMIN_USER=admin SFTPGO_ADMIN_PASSWORD=password sftpgo/get_admin_api_key.sh
 
 echo "Ensuring directories are present"
 source settings && mkdir -p $PDF_UPLOAD_PATH

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,9 @@ echo "Running migrations"
 lockfile=/mnt/news/goose-running
 source settings && flock $lockfile -c "goose -dir ./db/migrations mysql '$DB_USER:$DB_PASSWORD@tcp(db:3306)/$DB_DATABASE' up"
 
+echo "Get SFTPgo admin API key and store in NCA settings file"
+SETTINGS_PATH=settings SFTPGO_ADMIN_PASSWORD=password sftpgo/get_admin_api_key.sh
+
 echo "Ensuring directories are present"
 source settings && mkdir -p $PDF_UPLOAD_PATH
 source settings && mkdir -p $SCAN_UPLOAD_PATH

--- a/hugo/content/setup/sftpgo-integration.md
+++ b/hugo/content/setup/sftpgo-integration.md
@@ -74,8 +74,8 @@ Open up your settings file and jump to the SFTPGo section. If you're upgrading
 from an older version of NCA, you will have to copy this section from the
 example settings file into your production settings.
 
-You'll need to tell NCA how to connect to SFTPGo: set the API URL, store your
-admin credentials, and choose a default quota for new users.
+You'll need to tell NCA how to connect to SFTPGo: set the API URL and choose a
+default quota for new users.
 
 The API endpoint is simply the SFTPGo host combined with the path `/api/v2`.
 For our docker setup, the internal service is `http://sftpgo:8080`, so our API
@@ -83,16 +83,23 @@ configuration looks like this:
 
     SFTPGO_API_URL="http://sftpgo:8080/api/v2"
 
-The credentials simply need to match the admin account you created when setting
-up SFTPGo. e.g.:
-
-    SFTPGO_ADMIN_LOGIN=admin
-    SFTPGO_ADMIN_PASSWORD=password
-
 The default quota is five gigabytes, but you can adjust this as needed. You
 will likely want *something*, however: this ensures one publisher can't blast
 hundreds of gigs (or even terabytes) of data, taking your server down and
 preventing all other publishers from uploading anything.
+
+### SFTPGo API Key
+
+NCA connects to SFTPGo via an API key for a user with admin privileges. If you
+are using Docker with defaults for development, this API key is created and
+assigned in your NCA `settings` file automatically. For any non-development use,
+one will have to use the Bash scripts in the `sftpgo/` directory.
+`sftpgo/get_admin_api_key.sh` is the only script that *must* be run. It will
+prompt for admin user credentials, use them to request an API key for that user,
+and store the key in the NCA `settings` file automatically.
+
+Additional scripts are provided to list all API keys, test using the API key
+stored in the NCA `settings` file, and delete an API key.
 
 ## Usage
 

--- a/settings-example
+++ b/settings-example
@@ -73,9 +73,6 @@ DB_DATABASE="nca"
 # be the same URL you'd use in a browser for web-based administration.
 SFTPGO_API_URL="http://sftpgo:8080/api/v2"
 
-# The SFTPGo username for API requests
-SFTPGO_ADMIN_LOGIN=admin
-
 # The SFTPGo API key for API requests
 # Reset to 'sftpgo_admin_api_key' surrounded by exclamation points
 # and run sftpgo/get_admin_api_key.sh to get a new API key

--- a/settings-example
+++ b/settings-example
@@ -76,9 +76,6 @@ SFTPGO_API_URL="http://sftpgo:8080/api/v2"
 # The SFTPGo username for API requests
 SFTPGO_ADMIN_LOGIN=admin
 
-# The SFTPGo password for API requests
-SFTPGO_ADMIN_PASSWORD=password
-
 # The SFTPGo API key for API requests
 # Reset to 'sftpgo_admin_api_key' surrounded by exclamation points
 # and run sftpgo/get_admin_api_key.sh to get a new API key

--- a/settings-example
+++ b/settings-example
@@ -79,6 +79,11 @@ SFTPGO_ADMIN_LOGIN=admin
 # The SFTPGo password for API requests
 SFTPGO_ADMIN_PASSWORD=password
 
+# The SFTPGo API key for API requests
+# Reset to 'sftpgo_admin_api_key' surrounded by exclamation points
+# and run sftpgo/get_admin_api_key.sh to get a new API key
+SFTPGO_ADMIN_API_KEY=!sftpgo_admin_api_key!
+
 # How much disk each new user is allotted for uploads.  Note that this is NOT
 # retroactive.  This is simply the default used when a *new* title is sent to
 # SFTPGo.  Changing quotas for existing titles requires manual editing of their

--- a/sftpgo/delete_api_key.sh
+++ b/sftpgo/delete_api_key.sh
@@ -15,6 +15,10 @@ fi
 
 source ${SETTINGS_PATH}
 
+if [[ "${SFTPGO_ADMIN_LOGIN}" == "" ]]; then
+  read -p "Enter SFTPgo admin user: " SFTPGO_ADMIN_LOGIN
+fi
+
 if [[ "${SFTPGO_ADMIN_PASSWORD}" == "" ]]; then
   read -p "Enter SFTPgo admin password: " SFTPGO_ADMIN_PASSWORD
 fi

--- a/sftpgo/delete_api_key.sh
+++ b/sftpgo/delete_api_key.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Delete SFTPgo admin API key
+
+if [[ ! $(command -v jq) ]]; then
+  echo "jq required. Please install jq"
+  exit 1
+fi
+
+if [[ ! -r ${SETTINGS_PATH} ]]; then
+  echo "Can't read file at SETTINGS_PATH value: '${SETTINGS_PATH}'"
+  ls -l ${SETTINGS_PATH}
+  exit 1
+fi
+
+source ${SETTINGS_PATH}
+
+if [[ "${SFTPGO_ADMIN_PASSWORD}" == "" ]]; then
+  read -p "Enter SFTPgo admin password: " SFTPGO_ADMIN_PASSWORD
+fi
+
+BASE_URL=$(echo ${SFTPGO_API_URL} | sed -E 's/https?\:\/\///')
+TOKEN_URL="http://${SFTPGO_ADMIN_LOGIN}:${SFTPGO_ADMIN_PASSWORD}@${BASE_URL}/token"
+
+RESPONSE=$(curl -s --show-error ${TOKEN_URL})
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API token request"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API token request"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+TOKEN=$(
+  echo ${RESPONSE} \
+  | jq ".access_token" \
+  | sed 's/^"\(.*\)"$/\1/'
+)
+
+if [[ "$1" == "" ]]; then
+  read -p "Enter API key ID to delete: " API_KEY_ID
+else
+  API_KEY_ID=$1
+fi
+
+RESPONSE=$(curl -s --show-error -X DELETE ${SFTPGO_API_URL}/apikeys/${API_KEY_ID} \
+  -H "Authorization: Bearer ${TOKEN}")
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API request to delete API key ID ${API_KEY_ID}"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API request to delete API key ID ${API_KEY_ID}"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+echo "API key ID ${API_KEY_ID} delete response:"
+echo "${RESPONSE}" | jq
+

--- a/sftpgo/get_admin_api_key.sh
+++ b/sftpgo/get_admin_api_key.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Get SFTPgo admin API key and store in NCA settings file
+
+if [[ ! $(command -v jq) ]]; then
+  echo "jq required. Please install jq"
+  exit 1
+fi
+
+if [[ ! (-r ${SETTINGS_PATH} && -w ${SETTINGS_PATH}) ]]; then
+  echo "Can't read and write file at SETTINGS_PATH value: '${SETTINGS_PATH}'"
+  ls -l ${SETTINGS_PATH}
+  exit 1
+fi
+
+source ${SETTINGS_PATH}
+
+if [[ ! $(grep "!sftpgo_admin_api_key!" ${SETTINGS_PATH}) ]]; then
+  echo "SFTPgo admin API key already set in NCA settings"
+  $(dirname $0)/view_api_keys.sh
+  exit 0
+fi
+
+if [[ "${SFTPGO_ADMIN_PASSWORD}" == "" ]]; then
+  read -p "Enter SFTPgo admin password: " SFTPGO_ADMIN_PASSWORD
+fi
+
+BASE_URL=$(echo ${SFTPGO_API_URL} | sed -E 's/https?\:\/\///')
+TOKEN_URL="http://${SFTPGO_ADMIN_LOGIN}:${SFTPGO_ADMIN_PASSWORD}@${BASE_URL}/token"
+
+RESPONSE=$(curl -s --show-error ${TOKEN_URL})
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API token request"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API token request"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+TOKEN=$(
+  echo ${RESPONSE} \
+  | jq ".access_token" \
+  | sed 's/^"\(.*\)"$/\1/'
+)
+
+RESPONSE=$(curl -s --show-error -X PUT \
+  ${SFTPGO_API_URL}/${SFTPGO_ADMIN_LOGIN}/profile \
+  -H "Authorization: Bearer ${TOKEN}" -d' { "allow_api_key_auth": true }')
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API request to update admin profile to allow API key auth"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API request to update admin profile to allow API key auth"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+RESPONSE=$(curl -s --show-error -X POST ${SFTPGO_API_URL}/apikeys \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d" {
+    \"id\": \"001\",
+    \"name\": \"nca_admin\",
+    \"key\": \"key_pa55PHRA%E\",
+    \"scope\": 1,
+    \"description\": \"NCA Admin API Key\",
+    \"admin\": \"${SFTPGO_ADMIN_LOGIN}\"
+  }
+")
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API request to create admin API key"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API request to create admin API key"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+APIKEY=$(
+  echo ${RESPONSE} \
+  | jq ".key" \
+  | sed 's/^"\(.*\)"$/\1/'
+)
+
+echo "Ensuring global access to NCA settings file disabled:"
+echo "chmod o-rwx ${SETTINGS_PATH}"
+chmod o-rwx ${SETTINGS_PATH}
+
+echo "Writing SFTPgo admin API key to NCA settings file: ${SETTINGS_PATH}"
+# Copy approach needed to work with mounting settings file via Docker
+sed "s/!sftpgo_admin_api_key!/${APIKEY}/" ${SETTINGS_PATH} > /tmp/settings-updated
+cp /tmp/settings-updated ${SETTINGS_PATH}
+rm /tmp/settings-updated
+
+echo "Testing API key by requesting to view server status"
+$(dirname $0)/test_api_key.sh
+

--- a/sftpgo/get_admin_api_key.sh
+++ b/sftpgo/get_admin_api_key.sh
@@ -21,6 +21,10 @@ if [[ ! $(grep "!sftpgo_admin_api_key!" ${SETTINGS_PATH}) ]]; then
   exit 0
 fi
 
+if [[ "${SFTPGO_ADMIN_LOGIN}" == "" ]]; then
+  read -p "Enter SFTPgo admin user: " SFTPGO_ADMIN_LOGIN
+fi
+
 if [[ "${SFTPGO_ADMIN_PASSWORD}" == "" ]]; then
   read -p "Enter SFTPgo admin password: " SFTPGO_ADMIN_PASSWORD
 fi

--- a/sftpgo/test_api_key.sh
+++ b/sftpgo/test_api_key.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Test SFTPgo admin API key from settings to view server status
+
+if [[ ! $(command -v jq) ]]; then
+  echo "jq required. Please install jq"
+  exit 1
+fi
+
+if [[ ! -r ${SETTINGS_PATH} ]]; then
+  echo "Can't read file at SETTINGS_PATH value: '${SETTINGS_PATH}'"
+  ls -l ${SETTINGS_PATH}
+  exit 1
+fi
+
+source ${SETTINGS_PATH}
+
+RESPONSE=$(curl -s --show-error -X GET ${SFTPGO_API_URL}/status \
+  -H "X-SFTPGO-API-KEY: ${SFTPGO_ADMIN_API_KEY}")
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API request to view server status"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API request to view server status"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+echo "Server status:"
+echo "${RESPONSE}" | jq
+

--- a/sftpgo/view_api_keys.sh
+++ b/sftpgo/view_api_keys.sh
@@ -15,6 +15,10 @@ fi
 
 source ${SETTINGS_PATH}
 
+if [[ "${SFTPGO_ADMIN_LOGIN}" == "" ]]; then
+  read -p "Enter SFTPgo admin user: " SFTPGO_ADMIN_LOGIN
+fi
+
 if [[ "${SFTPGO_ADMIN_PASSWORD}" == "" ]]; then
   read -p "Enter SFTPgo admin password: " SFTPGO_ADMIN_PASSWORD
 fi

--- a/sftpgo/view_api_keys.sh
+++ b/sftpgo/view_api_keys.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# View SFTPgo admin API keys
+
+if [[ ! $(command -v jq) ]]; then
+  echo "jq required. Please install jq"
+  exit 1
+fi
+
+if [[ ! -r ${SETTINGS_PATH} ]]; then
+  echo "Can't read file at SETTINGS_PATH value: '${SETTINGS_PATH}'"
+  ls -l ${SETTINGS_PATH}
+  exit 1
+fi
+
+source ${SETTINGS_PATH}
+
+if [[ "${SFTPGO_ADMIN_PASSWORD}" == "" ]]; then
+  read -p "Enter SFTPgo admin password: " SFTPGO_ADMIN_PASSWORD
+fi
+
+BASE_URL=$(echo ${SFTPGO_API_URL} | sed -E 's/https?\:\/\///')
+TOKEN_URL="http://${SFTPGO_ADMIN_LOGIN}:${SFTPGO_ADMIN_PASSWORD}@${BASE_URL}/token"
+
+RESPONSE=$(curl -s --show-error ${TOKEN_URL})
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API token request"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq ".error") != "null" ]]; then
+  echo "Error in response from SFTPgo API token request"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+TOKEN=$(
+  echo ${RESPONSE} \
+  | jq ".access_token" \
+  | sed 's/^"\(.*\)"$/\1/'
+)
+
+RESPONSE=$(curl -s --show-error -X GET ${SFTPGO_API_URL}/apikeys \
+  -H "Authorization: Bearer ${TOKEN}")
+if [[ $? != 0 ]]; then
+  echo "Curl error with SFTPgo API request to see admin API keys"
+  exit 1
+elif [[ $(echo ${RESPONSE} | jq -e ".error?")  ]]; then
+  echo "Error in response from SFTPgo API request to see admin API keys"
+  echo ${RESPONSE} | jq
+  exit 1
+fi
+
+echo "Current API keys:"
+echo "${RESPONSE}" | jq
+

--- a/src/cmd/server/main.go
+++ b/src/cmd/server/main.go
@@ -56,7 +56,7 @@ func getConf() {
 	}
 
 	if conf.SFTPGoEnabled {
-		err = dbi.SFTPConnect(conf.SFTPGoAPIURL, conf.SFTPGoAdminLogin, conf.SFTPGoAdminPassword)
+		err = dbi.SFTPConnect(conf.SFTPGoAPIURL, conf.SFTPGoAdminLogin, conf.SFTPGoAdminAPIKey)
 		if err != nil {
 			logger.Fatalf("Error trying to connect to SFTPGo: %s", err)
 		}

--- a/src/cmd/server/main.go
+++ b/src/cmd/server/main.go
@@ -56,7 +56,7 @@ func getConf() {
 	}
 
 	if conf.SFTPGoEnabled {
-		err = dbi.SFTPConnect(conf.SFTPGoAPIURL, conf.SFTPGoAdminLogin, conf.SFTPGoAdminAPIKey)
+		err = dbi.SFTPConnect(conf.SFTPGoAPIURL, conf.SFTPGoAdminAPIKey)
 		if err != nil {
 			logger.Fatalf("Error trying to connect to SFTPGo: %s", err)
 		}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -23,11 +23,11 @@ type Config struct {
 	DBPort int `setting:"DB_PORT" type:"int"`
 
 	// SFTPGo settings
-	SFTPGoEnabled       bool
-	SFTPGoAPIURL        *url.URL
-	SFTPGoAdminLogin    string `setting:"SFTPGO_ADMIN_LOGIN"`
-	SFTPGoAdminPassword string `setting:"SFTPGO_ADMIN_PASSWORD"`
-	SFTPGoNewUserQuota  datasize.Datasize
+	SFTPGoEnabled      bool
+	SFTPGoAPIURL       *url.URL
+	SFTPGoAdminLogin   string `setting:"SFTPGO_ADMIN_LOGIN"`
+	SFTPGoAdminAPIKey  string `setting:"SFTPGO_ADMIN_API_KEY"`
+	SFTPGoNewUserQuota datasize.Datasize
 
 	// Binary paths
 	GhostScript   string `setting:"GHOSTSCRIPT"`

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -25,7 +25,6 @@ type Config struct {
 	// SFTPGo settings
 	SFTPGoEnabled      bool
 	SFTPGoAPIURL       *url.URL
-	SFTPGoAdminLogin   string `setting:"SFTPGO_ADMIN_LOGIN"`
 	SFTPGoAdminAPIKey  string `setting:"SFTPGO_ADMIN_API_KEY"`
 	SFTPGoNewUserQuota datasize.Datasize
 

--- a/src/dbi/dbi.go
+++ b/src/dbi/dbi.go
@@ -41,9 +41,9 @@ func DBConnect(connect string) error {
 	return nil
 }
 
-// SFTPConnect sets up the global SFTPGo API instance and attempts to grab a token
-func SFTPConnect(u *url.URL, user, pass string) error {
-	SFTP = sftpgo.New(u, user, pass)
-	var err = SFTP.GetToken()
+// SFTPConnect sets up the global SFTPGo API instance and checks server status
+func SFTPConnect(u *url.URL, user, apikey string) error {
+	SFTP = sftpgo.New(u, user, apikey)
+	var err = SFTP.GetStatus()
 	return err
 }

--- a/src/dbi/dbi.go
+++ b/src/dbi/dbi.go
@@ -42,8 +42,8 @@ func DBConnect(connect string) error {
 }
 
 // SFTPConnect sets up the global SFTPGo API instance and checks server status
-func SFTPConnect(u *url.URL, user, apikey string) error {
-	SFTP = sftpgo.New(u, user, apikey)
+func SFTPConnect(u *url.URL, apikey string) error {
+	SFTP = sftpgo.New(u, apikey)
 	var err = SFTP.GetStatus()
 	return err
 }

--- a/src/internal/sftpgo/sftpgo.go
+++ b/src/internal/sftpgo/sftpgo.go
@@ -34,7 +34,6 @@ func rndPass() string {
 // API is used to send API requests to the SFTPGo daemon
 type API struct {
 	url     *url.URL
-	login   string
 	apikey  string
 	now     func() time.Time
 	do      func(c *http.Client, req *http.Request) ([]byte, error)
@@ -42,13 +41,12 @@ type API struct {
 }
 
 // New returns a new API instance for sending requests to SFTPGo
-func New(apiURL *url.URL, login, apikey string) *API {
+func New(apiURL *url.URL, apikey string) *API {
 	if apiURL == nil {
 		panic("cannot instantiate API with no URL")
 	}
 
 	var a = &API{
-		login:   login,
 		apikey:  apikey,
 		url:     apiURL,
 		now:     time.Now,

--- a/src/internal/sftpgo/sftpgo_test.go
+++ b/src/internal/sftpgo/sftpgo_test.go
@@ -44,12 +44,12 @@ func (s *spy) do(c *http.Client, req *http.Request) ([]byte, error) {
 }
 
 // newAPI returns a hacked-up API and its spy (mock?  double?  Meh).  By
-// default the API will use the spy to send fake requests, with a token request
+// default the API will use the spy to send fake requests, with an api request
 // already pre-set-up.  The API's "now" method will also default to a time just
 // before the token expiry for easier testing.
 func newAPI(t *testing.T) (*API, *spy) {
 	var u, _ = url.Parse("http://example.org/api/v2")
-	var a = New(u, "user", "pass")
+	var a = New(u, "pass")
 	var s = makeSpy()
 	a.now = makeNow(time.Date(2021, 1, 17, 9, 25, 0, 0, time.UTC))
 	a.do = s.do

--- a/src/internal/sftpgo/sftpgo_test.go
+++ b/src/internal/sftpgo/sftpgo_test.go
@@ -15,7 +15,7 @@ type request struct {
 	url      string
 }
 
-const exampleToken = `{"access_token":"faketoken","expires_at":"2021-01-17T09:32:29Z"}`
+const exampleStatus = `{"message":"Server fully operational"}`
 
 type spy struct {
 	requests  []request
@@ -28,9 +28,9 @@ func makeSpy() *spy {
 		responses: make(map[string][]byte),
 		errors:    make(map[string]error),
 	}
-	// Default to have a valid token response in all cases
-	s.responses["token"] = []byte(exampleToken)
-	s.errors["token"] = nil
+	// Default to have a valid API key and successful server status response
+	s.responses["status"] = []byte(exampleStatus)
+	s.errors["status"] = nil
 	return s
 }
 
@@ -62,19 +62,11 @@ func makeNow(t time.Time) func() time.Time {
 	}
 }
 
-func TestToken(t *testing.T) {
+func TestApiKey(t *testing.T) {
 	var a, s = newAPI(t)
-	var err = a.GetToken()
+	var err = a.GetStatus()
 	if err != nil {
-		t.Fatalf("Couldn't retrieve token: %s", err)
-	}
-	if a.token.AccessToken != "faketoken" {
-		t.Errorf(`Access token should have been "faketoken", but was %q`, a.token.AccessToken)
-	}
-
-	var expected = time.Date(2021, 1, 17, 9, 25, 10, 0, time.UTC)
-	if a.token.ExpiresAt != expected {
-		t.Errorf(`ExpiresAt should have been %q, but was %q`, expected.Format(time.RFC3339Nano), a.token.ExpiresAt.Format(time.RFC3339Nano))
+		t.Fatalf("Couldn't retrieve status: %s", err)
 	}
 
 	// Make sure the request was set up properly
@@ -82,24 +74,10 @@ func TestToken(t *testing.T) {
 		t.Errorf("More requests than expected: %#v", s.requests)
 	}
 	var r = s.requests[0]
-	var expectedURL = "http://user:pass@example.org/api/v2/token"
+	var expectedURL = "http://example.org/api/v2/status"
 	var gotURL = r.url
 	if expectedURL != gotURL {
 		t.Errorf("Expected request URL %q, got %q", expectedURL, gotURL)
-	}
-
-	// Make sure the token isn't requested a second time if it hasn't expired
-	a.token.ExpiresAt = a.now().Add(time.Second)
-	a.GetToken()
-	if len(s.requests) != 1 {
-		t.Errorf("doToken caused an extra HTTP request despite token still being valid")
-	}
-
-	// If the token has expired, a new one should be issued immediately
-	a.token.ExpiresAt = a.now().Add(-time.Second)
-	a.GetToken()
-	if len(s.requests) != 2 {
-		t.Errorf("doToken should have requested a new token since the current is expired")
 	}
 }
 
@@ -114,14 +92,11 @@ func TestCreateUser(t *testing.T) {
 	if err != nil {
 		t.Errorf("CreateUser should have had no errors, but it returned %s", err)
 	}
-	if len(s.requests) != 2 {
-		t.Errorf("Expected two requests, but got %d", len(s.requests))
+	if len(s.requests) != 1 {
+		t.Errorf("Expected one request, but got %d", len(s.requests))
 	}
-	if s.requests[0].function != "token" {
-		t.Errorf("First request should have been for a token, but it was %#v", s.requests[0])
-	}
-	if s.requests[1].function != "users" {
-		t.Errorf("Second request should have been for the user, but it was %#v", s.requests[1])
+	if s.requests[0].function != "users" {
+		t.Errorf("Request should have been for the user, but it was %#v", s.requests[1])
 	}
 	if pass != fakepass {
 		t.Errorf("Expected password to be %q, got %q", fakepass, pass)
@@ -140,14 +115,11 @@ func TestCreateUser_WithPassword(t *testing.T) {
 	if err != nil {
 		t.Errorf("CreateUser should have had no errors, but it returned %s", err)
 	}
-	if len(s.requests) != 2 {
-		t.Errorf("Expected two requests, but got %d", len(s.requests))
+	if len(s.requests) != 1 {
+		t.Errorf("Expected one request, but got %d", len(s.requests))
 	}
-	if s.requests[0].function != "token" {
-		t.Errorf("First request should have been for a token, but it was %#v", s.requests[0])
-	}
-	if s.requests[1].function != "users" {
-		t.Errorf("Second request should have been for the user, but it was %#v", s.requests[1])
+	if s.requests[0].function != "users" {
+		t.Errorf("Request should have been for the user, but it was %#v", s.requests[1])
 	}
 	if pass != fakepass {
 		t.Errorf("Expected password to be %q, got %q", fakepass, pass)
@@ -163,13 +135,10 @@ func TestUpdateUser(t *testing.T) {
 	if err != nil {
 		t.Errorf("UpdateUser should have had no errors, but it returned %s", err)
 	}
-	if len(s.requests) != 2 {
-		t.Errorf("Expected two requests, but got %d", len(s.requests))
+	if len(s.requests) != 1 {
+		t.Errorf("Expected one requests, but got %d", len(s.requests))
 	}
-	if s.requests[0].function != "token" {
-		t.Errorf("First request should have been for a token, but it was %#v", s.requests[0])
-	}
-	if s.requests[1].function != "users/fakename" {
-		t.Errorf("Second request should have been for the user, but it was %#v", s.requests[1])
+	if s.requests[0].function != "users/fakename" {
+		t.Errorf("Request should have been for the user, but it was %#v", s.requests[1])
 	}
 }


### PR DESCRIPTION
Closes #192 

Add SFTPgo admin API key scripts and setting

Replace SFTPgo JWT auth with admin API key auth

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>