### PR TITLE
Feature/fix flagging batch issues

### DIFF
--- a/changelogs/2022-10-17-fix-flagging-issues.md
+++ b/changelogs/2022-10-17-fix-flagging-issues.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Flagging issues from the batch status view will no longer result in a crash
+  of the workers daemon. OUCH.

--- a/src/jobs/batch_flagged_issue_jobs.go
+++ b/src/jobs/batch_flagged_issue_jobs.go
@@ -47,6 +47,7 @@ func (j *FinalizeBatchFlaggedIssue) Process(*config.Config) bool {
 	j.Logger.Debugf("Successfully created 'removed from batch' issue action")
 
 	// Update database: clear batch, workflow metadata, and set status
+	var oldBatchID = i.BatchID
 	i.BatchID = 0
 	i.WorkflowOwnerID = 0
 	i.WorkflowOwnerExpiresAt = time.Time{}
@@ -61,7 +62,7 @@ func (j *FinalizeBatchFlaggedIssue) Process(*config.Config) bool {
 
 	// Find flagged issue to get the error message
 	var flagged *models.FlaggedIssue
-	flagged, err = models.FindFlaggedIssue(i.BatchID, i.ID)
+	flagged, err = models.FindFlaggedIssue(oldBatchID, i.ID)
 	if err != nil {
 		j.Logger.Errorf("Unable to create 'removed from batch' issue action: %s", err)
 		op.Rollback()

--- a/src/models/issue.go
+++ b/src/models/issue.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -128,7 +129,7 @@ func FindFlaggedIssue(batchID, issueID int) (*FlaggedIssue, error) {
 		return nil, err
 	}
 	if len(list) == 0 {
-		return nil, nil
+		return nil, sql.ErrNoRows
 	}
 	return list[0], err
 }


### PR DESCRIPTION
Closes #205 

Verifies existence of flagged issue when workers are running to avoid a crash, and fixes the batch id sent to the query in the first place so it's unlikely we'll be getting an empty result in the first place.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>