### PR TITLE
Hotfix/sftpgo expire token faster

### DIFF
--- a/changelogs/2022-10-18-hotfix-sftpgo-token.md
+++ b/changelogs/2022-10-18-hotfix-sftpgo-token.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Title page should not longer spit out errors about being unable to display
+  titles due to the SFTPGo connection (tokens are refreshed after 10 seconds
+  instead of respecting their expiry time)

--- a/src/internal/sftpgo/sftpgo.go
+++ b/src/internal/sftpgo/sftpgo.go
@@ -13,6 +13,8 @@ import (
 	"path"
 	"sync"
 	"time"
+
+	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 )
 
 func rndPass() string {
@@ -143,6 +145,7 @@ func (a *API) rpc(method, function string, data string) ([]byte, error) {
 			return nil, err
 		}
 	}
+	logger.Debugf("Trying to get token via %#v", endpoint.String())
 
 	var c = &http.Client{Timeout: time.Minute}
 	var req, err = http.NewRequest(method, endpoint.String(), bytes.NewBuffer([]byte(data)))
@@ -181,6 +184,8 @@ func (a *API) GetToken() error {
 	a.m.Lock()
 	defer a.m.Unlock()
 
+	logger.Debugf("Token expires at %#v", a.token.ExpiresAt)
+	logger.Debugf("Now: %#v", a.now())
 	if a.token.ExpiresAt.After(a.now()) {
 		return nil
 	}

--- a/src/internal/sftpgo/sftpgo.go
+++ b/src/internal/sftpgo/sftpgo.go
@@ -181,7 +181,7 @@ func (a *API) GetToken() error {
 	a.m.Lock()
 	defer a.m.Unlock()
 
-	if a.token.ExpiresAt.Sub(a.now()) > (3 * time.Minute) {
+	if a.token.ExpiresAt.After(a.now()) {
 		return nil
 	}
 
@@ -190,5 +190,10 @@ func (a *API) GetToken() error {
 		return fmt.Errorf("unable to retrieve token: %w", err)
 	}
 
-	return json.Unmarshal(data, a.token)
+	// Hack up the expiry time to be extremely short. SFTPGo seems to either be
+	// giving us incorrect times or expiring too soon.
+	err = json.Unmarshal(data, a.token)
+	a.token.ExpiresAt = a.now().Add(time.Second * 10)
+
+	return err
 }

--- a/src/internal/sftpgo/sftpgo_test.go
+++ b/src/internal/sftpgo/sftpgo_test.go
@@ -72,7 +72,7 @@ func TestToken(t *testing.T) {
 		t.Errorf(`Access token should have been "faketoken", but was %q`, a.token.AccessToken)
 	}
 
-	var expected = time.Date(2021, 1, 17, 9, 32, 29, 0, time.UTC)
+	var expected = time.Date(2021, 1, 17, 9, 25, 10, 0, time.UTC)
 	if a.token.ExpiresAt != expected {
 		t.Errorf(`ExpiresAt should have been %q, but was %q`, expected.Format(time.RFC3339Nano), a.token.ExpiresAt.Format(time.RFC3339Nano))
 	}
@@ -89,13 +89,14 @@ func TestToken(t *testing.T) {
 	}
 
 	// Make sure the token isn't requested a second time if it hasn't expired
+	a.token.ExpiresAt = a.now().Add(time.Second)
 	a.GetToken()
 	if len(s.requests) != 1 {
 		t.Errorf("doToken caused an extra HTTP request despite token still being valid")
 	}
 
-	// If the token's about to expire, a new one should be issued
-	a.token.ExpiresAt = time.Date(2021, 1, 17, 9, 26, 0, 0, time.UTC)
+	// If the token has expired, a new one should be issued immediately
+	a.token.ExpiresAt = a.now().Add(-time.Second)
 	a.GetToken()
 	if len(s.requests) != 2 {
 		t.Errorf("doToken should have requested a new token since the current is expired")


### PR DESCRIPTION
This is a hotfix to deal with an odd bug that may be on the NCA side (very likely) or could be a bug in the implementation of SFTPGo's token expiry (not likely). Either way, this fix isn't expected to last long, but it's causing production issues so ... in it goes.

This will receive no code review because (a) it's causing production-level problems, and (b) I don't make mistakes. Please don't look at other recent work for proof of mistakes I've made.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>