### PR TITLE
Hotfix/batch flagging ii

### DIFF
--- a/manage
+++ b/manage
@@ -9,6 +9,12 @@ nuke() {
   echo "Done (Deleting the stack)"
 }
 
+dcup() {
+  echo "Starting up key docker services"
+  docker-compose up -d iiif sftpgo db
+  echo "Done (Starting up key docker services)"
+}
+
 backup() {
   dir=$(realpath $1)
   mkdir -p $dir
@@ -28,6 +34,8 @@ backup() {
   sudo tar -cf $fakemount ./test/fakemount
   sudo su -c "cd /var/lib/docker/volumes && tar -cf $vols ./nca*"
   echo "Done (Writing new backup files)"
+
+  dcup
 }
 
 migrate() {
@@ -49,6 +57,8 @@ restore() {
   sudo tar -xf $fakemount ./test/fakemount
   sudo su -c "cd /var/lib/docker/volumes && tar -xf $vols"
   echo "Done (Restoring from $dir)"
+
+  dcup
 }
 
 build() {

--- a/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
+++ b/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
@@ -247,5 +247,5 @@ func finalizeBatch(r *Responder) {
 	}
 
 	http.SetCookie(r.Writer, &http.Cookie{Name: "Info", Value: fmt.Sprintf("A background job has been queued to finalize batch %q", r.batch.Name), Path: "/"})
-	http.Redirect(r.Writer, r.Request, batchURL(r.batch), http.StatusFound)
+	http.Redirect(r.Writer, r.Request, basePath, http.StatusFound)
 }

--- a/src/cmd/server/internal/batchhandler/handlers.go
+++ b/src/cmd/server/internal/batchhandler/handlers.go
@@ -137,5 +137,5 @@ func qcRejectHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	http.SetCookie(r.Writer, &http.Cookie{Name: "Info", Value: r.batch.Name + ": failed QC, ready to flag issues for removal", Path: "/"})
-	http.Redirect(w, req, basePath, http.StatusFound)
+	http.Redirect(w, req, batchURL(r.batch), http.StatusFound)
 }

--- a/src/models/batch.go
+++ b/src/models/batch.go
@@ -310,7 +310,7 @@ func (b *Batch) UnflagIssue(i *Issue) error {
 // AbortIssueFlagging returns the batch state to BatchStatusQCReady and removes
 // all flagged issues tied to it
 func (b *Batch) AbortIssueFlagging() error {
-	if b.Status != BatchStatusQCFlagIssues {
+	if b.Status != BatchStatusQCFlagIssues && b.Status != BatchStatusPending {
 		return fmt.Errorf("abort issue flagging: invalid batch status %s", b.Status)
 	}
 


### PR DESCRIPTION
Fixes a bug in batch processing that would result in a batch that had flagged issues never being able to be rebuilt. Also fixes unintuitive redirects, and makes the dev "manage" commands restart key parts of the stack (sftpgo, iiif, and db)

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [ ] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>