### PR TITLE
Fix env var typo; Improve entrypoint and docs

### DIFF
--- a/changelogs/2022-11-28-sftpgo-api-key-auth.md
+++ b/changelogs/2022-11-28-sftpgo-api-key-auth.md
@@ -8,6 +8,7 @@
 ### Migration
 - If using SFTPGo integration, `settings` now requires `SFTPGO_ADMIN_API_KEY`
   and drops `SFTPGO_ADMIN_LOGIN` and `SFTPGO_ADMIN_PASSWORD`. Copy the relevant
-  section from `settings-example` and run `sftpgo/get_admin_api_key.sh` to issue
-  an admin API key and automatically store it in `settings`.
+  section from `settings-example` and run `SETTINGS_PATH=/path/to/settings
+  sftpgo/get_admin_api_key.sh` to issue an admin API key and automatically store
+  it in `settings`.
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ lockfile=/mnt/news/goose-running
 source settings && flock $lockfile -c "goose -dir ./db/migrations mysql '$DB_USER:$DB_PASSWORD@tcp(db:3306)/$DB_DATABASE' up"
 
 echo "Get SFTPgo admin API key and store in NCA settings file"
-SETTINGS_PATH=settings SFTPGO_ADMIN_USER=admin SFTPGO_ADMIN_PASSWORD=password sftpgo/get_admin_api_key.sh
+flock /mnt/news/get-sftpgo-api-key-running -c "SETTINGS_PATH=settings SFTPGO_ADMIN_LOGIN=admin SFTPGO_ADMIN_PASSWORD=password sftpgo/get_admin_api_key.sh"
 
 echo "Ensuring directories are present"
 source settings && mkdir -p $PDF_UPLOAD_PATH

--- a/hugo/content/setup/sftpgo-integration.md
+++ b/hugo/content/setup/sftpgo-integration.md
@@ -93,13 +93,17 @@ preventing all other publishers from uploading anything.
 NCA connects to SFTPGo via an API key for a user with admin privileges. If you
 are using Docker with defaults for development, this API key is created and
 assigned in your NCA `settings` file automatically. For any non-development use,
-one will have to use the Bash scripts in the `sftpgo/` directory.
-`sftpgo/get_admin_api_key.sh` is the only script that *must* be run. It will
-prompt for admin user credentials, use them to request an API key for that user,
-and store the key in the NCA `settings` file automatically.
+one will have to use the Bash scripts in the `sftpgo/` directory. You will need
+to provide the environment variable `SETTINGS_PATH` with a value corresponding
+to the path to your NCA `settings` file to these Bash scripts.
+`SETTINGS_PATH=/path/to/settings sftpgo/get_admin_api_key.sh` is the only script
+that *must* be run. It will prompt for admin user credentials, use them to
+request an API key for that user, store the key in the NCA `settings` file
+automatically, and then call the accompanying script `test_api_key.sh` to test
+that API key.
 
-Additional scripts are provided to list all API keys, test using the API key
-stored in the NCA `settings` file, and delete an API key.
+Other accompanying scripts are provided to list all API keys and delete an API
+key.
 
 ## Usage
 


### PR DESCRIPTION
- Add flock in entrypoint.sh to prevent issuing more than one admin API key
- Docs and changelog migration note need to inform about SETTINGS_PATH env var for use of API key scripts

Close #221 

Review request: @jechols 

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>
