### PR TITLE
update gopkg to v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.3.0
 	github.com/gorilla/mux v1.7.0
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/uoregon-libraries/gopkg v0.18.0
+	github.com/uoregon-libraries/gopkg v0.19.0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,10 @@ github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK86
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/uoregon-libraries/gopkg v0.18.0 h1:a/7tGpnnaijK0MpgEDklHVFln1cVyOJyaQjQzxn3Dl8=
 github.com/uoregon-libraries/gopkg v0.18.0/go.mod h1:pNXCq9en+GoGKyz4Qkaz0brgjKtNp3FlwUQ/VvQGPes=
+github.com/uoregon-libraries/gopkg v0.18.1 h1:dJlCogEKiJMjsGWR1Ng6EkYnkekYaMsTHrwdyfsb8W8=
+github.com/uoregon-libraries/gopkg v0.18.1/go.mod h1:pNXCq9en+GoGKyz4Qkaz0brgjKtNp3FlwUQ/VvQGPes=
+github.com/uoregon-libraries/gopkg v0.19.0 h1:DVkI9sIYuLMbz5YNZw/ZgdIQXf4ZV26aWHrLPQ7x+bk=
+github.com/uoregon-libraries/gopkg v0.19.0/go.mod h1:pNXCq9en+GoGKyz4Qkaz0brgjKtNp3FlwUQ/VvQGPes=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=


### PR DESCRIPTION
This fixes how the ".manifest" files validate equivalency so that time zones and monotonic clocks won't cause problems

## Normal contributors

I have done all of the following:

- [ ] Fixes and new features have unit tests where applicable
- [ ] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [ ] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>