### PR TITLE
Feature/docker update

### DIFF
--- a/changelogs/2022-12-21-docker-compose.md
+++ b/changelogs/2022-12-21-docker-compose.md
@@ -1,0 +1,12 @@
+### Changed
+
+- All invocations of `docker-compose` are now `docker compose` (note the space
+  instead of the hyphen) so people installing docker and compose in the past
+  year or two aren't confused (or laughing at how outdated NCA is).
+
+### Migration
+
+- Make sure you have compose installed as a plugin, as detailed in Docker's
+  [documentation][compose-install].
+
+[compose-install]: <https://docs.docker.com/compose/install/>

--- a/docker/tag-latest.sh
+++ b/docker/tag-latest.sh
@@ -6,7 +6,7 @@ tag=$(git describe --abbrev=0)
 dname=uolibraries/nca_app
 
 git co $tag
-docker-compose build app
+docker compose build app
 docker rmi $dname:$tag || true
 docker tag $dname $dname:$tag
 

--- a/env-example
+++ b/env-example
@@ -1,4 +1,4 @@
-# Copy this to .env and modify to give docker-compose preset environment vars
+# Copy this to .env and modify to give docker compose preset environment vars
 
 # APP_URL tells NCA how it would build a URL for things like the RAIS image server
 APP_URL=http://localhost
@@ -6,7 +6,7 @@ APP_URL=http://localhost
 # NCA_NEWS_WEBROOT tells NCA where to find the live newspaper issues
 NCA_NEWS_WEBROOT=https://oregonnews.uoregon.edu
 
-# COMPOSE_PROJECT_NAME ensures all `docker-compose` commands use "nca" as the
+# COMPOSE_PROJECT_NAME ensures all `docker compose` commands use "nca" as the
 # project name so that if you rename the directory in which your code resides,
 # you don't "lose" the image, containers, and volumes.
 COMPOSE_PROJECT_NAME=nca

--- a/hugo/content/contributing/dev-guide.md
+++ b/hugo/content/contributing/dev-guide.md
@@ -24,7 +24,7 @@ simpler install, but there are a few considerations.  See
 ### Docker
 
 Install [Docker CE](https://docs.docker.com/install/), which will give you the
-`docker` and `docker-compose` commands.
+`docker` and `docker compose` commands.
 
 As mentioned before, Docker is the preferred method for development.  Manual
 setup instructions would be needlessly complicated to handle installing the
@@ -58,7 +58,7 @@ debug mode.
     cp env-example .env
     vim .env
 
-`.env` sets up default environment variables which `docker-compose` commands
+`.env` sets up default environment variables which `docker compose` commands
 will use.  A sample file might look like this:
 
 ```bash
@@ -82,8 +82,8 @@ into the container.
 
 #### Get all images
 
-    docker-compose build
-    docker-compose pull
+    docker compose build
+    docker compose pull
 
 Building the NCA application image will take a long time.  Grab some coffee.
 And maybe a nap....
@@ -94,7 +94,7 @@ openjpeg) and only update what has changed (e.g., NCA source code).
 
 #### Start the stack
 
-Run `docker-compose up`, and the application will be available at
+Run `docker compose up`, and the application will be available at
 `$APP_URL/nca`.  Note that on the first run it will take a while to respond as
 the system is caching all known issues - including those on the defined live
 site.
@@ -135,7 +135,7 @@ comprehensive end-to-end testing is explained in the
 Here's a nice shortcut one can use to speed up the process since, unlike PHP,
 this project requires compilation before it starts up:
 
-    alias dc='docker-compose'
+    alias dc='docker compose'
     make fast
     dc restart web proxy workers
     dc logs -f web proxy workers

--- a/hugo/content/contributing/testing.md
+++ b/hugo/content/contributing/testing.md
@@ -22,7 +22,7 @@ This is clunky and hacky, but it's what we've got for now.  How it all works:
 
 ### Setup
 
-- Get NCA working via docker-compose (see our
+- Get NCA working via docker compose (see our
   [Development Guide](/contributing/dev-guide); this whole <s>brittle mess</s>
   test suite depends on testing on a docker-enabled system)
 - Make sure your docker compose overrides mount `test/fakemount` as
@@ -120,11 +120,11 @@ directory has issues, you're ready to actually use the data:
   - `make-older.sh` will fake the files' age so the issues can be processed in
     the app without the "too new" warning.
   - *Wait*.  It takes a few minutes for the workers to scan for page reviews
-    (you can watch them via `docker-compose logs -f workers`), and then a few
+    (you can watch them via `docker compose logs -f workers`), and then a few
     more for the web cache to get updated.
 - Enter metadata, review metadata, and fire off a batch when ready
   - Queueing a batch through docker:
-    - `docker-compose exec workers /usr/local/nca/bin/queue-batches -c ./settings`
+    - `docker compose exec workers /usr/local/nca/bin/queue-batches -c ./settings`
   - The batch will end up in `test/fakemount/outgoing`
 
 ### Saving State

--- a/manage
+++ b/manage
@@ -3,15 +3,15 @@ set -eu
 
 nuke() {
   echo "Deleting the stack"
-  docker-compose kill
-  docker-compose down -v
+  docker compose kill
+  docker compose down -v
   rm ./test/fakemount/* -rf
   echo "Done (Deleting the stack)"
 }
 
 dcup() {
   echo "Starting up key docker services"
-  docker-compose up -d iiif sftpgo db
+  docker compose up -d iiif sftpgo db
   echo "Done (Starting up key docker services)"
 }
 
@@ -20,7 +20,7 @@ backup() {
   mkdir -p $dir
 
   echo "Taking down the stack gracefully"
-  docker-compose down
+  docker compose down
   echo "Done (Taking down the stack gracefully)"
 
   echo "Deleting old backups (if any)"
@@ -39,12 +39,12 @@ backup() {
 }
 
 migrate() {
-  docker-compose run --rm workers wait_for_database
+  docker compose run --rm workers wait_for_database
 }
 
 load_seed_data() {
-  docker-compose run --rm workers wait_for_database
-  docker-compose run --rm workers mysql -unca -pnca -Dnca -hdb < ./docker/mysql/nca-seed-data.sql
+  docker compose run --rm workers wait_for_database
+  docker compose run --rm workers mysql -unca -pnca -Dnca -hdb < ./docker/mysql/nca-seed-data.sql
 }
 
 restore() {
@@ -68,7 +68,7 @@ restore() {
 
 build() {
   echo "Building NCA images"
-  docker-compose build
+  docker compose build
   echo "Done (Building NCA images)"
 }
 
@@ -85,7 +85,7 @@ resetfakemount() {
 reset() {
   echo "Resetting the stack"
   build
-  docker-compose down -v
+  docker compose down -v
   migrate
   load_seed_data
   resetfakemount

--- a/scripts/localdev.sh
+++ b/scripts/localdev.sh
@@ -21,8 +21,8 @@ wait_for_database() {
 
 # Resets the database, deleting and rebuilding all the seed data
 resetdb() {
-  docker-compose down -v
-  docker-compose up -d db iiif sftpgo
+  docker compose down -v
+  docker compose up -d db iiif sftpgo
   wait_for_database && migrate && load_seed_data
 }
 
@@ -39,9 +39,9 @@ prep_for_testing() {
 
   # Reset the IIIF and SFTPGo services since they'll be looking at a mount
   # point we just deleted
-  docker-compose stop iiif sftpgo
-  docker-compose rm -f iiif sftpgo
-  docker-compose up -d iiif sftpgo
+  docker compose stop iiif sftpgo
+  docker compose rm -f iiif sftpgo
+  docker compose up -d iiif sftpgo
 }
 
 # Sets up all fake uploads from the test/fakemount dir, then bulk-queues all
@@ -85,7 +85,7 @@ upload_server() {
 }
 
 server() {
-  docker-compose up -d db iiif sftpgo
+  docker compose up -d db iiif sftpgo
   wait_for_database
   make bin/server || return 1
   echo
@@ -99,7 +99,7 @@ server() {
 }
 
 workers() {
-  docker-compose up -d db iiif sftpgo
+  docker compose up -d db iiif sftpgo
   wait_for_database
   make bin/run-jobs || return 1
   ./bin/run-jobs -c ./settings -v watchall

--- a/test/copy-sources.go
+++ b/test/copy-sources.go
@@ -13,7 +13,7 @@
 // in any direct way.
 //
 // Eventually this should be part of a bigger test suite which lives in its own
-// test-only docker-compose setup, runs various jobs, and tests output.
+// test-only docker compose setup, runs various jobs, and tests output.
 
 package main
 

--- a/test/reset.sh
+++ b/test/reset.sh
@@ -5,15 +5,15 @@ pushd .
 cd ..
 
 # Fry the issues, jobs, and batches from the database
-docker-compose up -d db
-docker-compose run --rm workers wait_for_database
-docker-compose exec db mysql -unca -pnca -Dnca -e "delete from jobs; delete from issues; delete from job_logs; delete from batches;"
+docker compose up -d db
+docker compose run --rm workers wait_for_database
+docker compose exec db mysql -unca -pnca -Dnca -e "delete from jobs; delete from issues; delete from job_logs; delete from batches;"
 
-docker-compose down
+docker compose down
 
 # Remove the finder cache, but *not* the cached web data - this gives us a
 # quicker upstart since we'll only have to rescan the filesystem
-docker-compose run --rm workers rm -f /var/local/news/nca/cache/finder.cache
+docker compose run --rm workers rm -f /var/local/news/nca/cache/finder.cache
 
 popd
 ./makemine.sh


### PR DESCRIPTION
Closes #233 

Uses `docker compose` over `docker-compose`

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>