### PR TITLE
get_admin_api_key.sh: allow force-getting api key

### DIFF
--- a/changelogs/2023-01-09-sftpgo-get-key.md
+++ b/changelogs/2023-01-09-sftpgo-get-key.md
@@ -1,0 +1,4 @@
+### Added
+
+- `sftpgo/get_admin_api_key.sh` now has an optional flag to force it to
+  overwrite an existing key in `settings`.

--- a/hugo/content/setup/sftpgo-integration.md
+++ b/hugo/content/setup/sftpgo-integration.md
@@ -92,7 +92,7 @@ preventing all other publishers from uploading anything.
 
 NCA connects to SFTPGo via an API key for a user with admin privileges. If you
 are using Docker with defaults for development, this API key is created and
-assigned in your NCA `settings` file automatically. For any non-development use,
+assigned in your NCA `settings` file automatically. For any non-docker use,
 one will have to use the Bash scripts in the `sftpgo/` directory. You will need
 to provide the environment variable `SETTINGS_PATH` with a value corresponding
 to the path to your NCA `settings` file to these Bash scripts.
@@ -101,6 +101,15 @@ that *must* be run. It will prompt for admin user credentials, use them to
 request an API key for that user, store the key in the NCA `settings` file
 automatically, and then call the accompanying script `test_api_key.sh` to test
 that API key.
+
+Normally you only run `get_admin_api_key.sh` once, but if you need to reacquire
+a key, you must reset your `settings` file (set
+`SFTPGO_ADMIN_API_KEY=!sftpgo_admin_api_key!`) and then re-run this script.
+
+Note that you can instead run `get_admin_api_key.sh` with the `--force` flag to
+overwrite an existing key in your `settings` file. This should rarely be
+necessary in a production environment, but can be useful on a development or
+staging system where the stack may be destroyed and rebuilt regularly.
 
 Other accompanying scripts are provided to list all API keys and delete an API
 key.

--- a/sftpgo/get_admin_api_key.sh
+++ b/sftpgo/get_admin_api_key.sh
@@ -15,10 +15,12 @@ fi
 
 source ${SETTINGS_PATH}
 
-if [[ ! $(grep "!sftpgo_admin_api_key!" ${SETTINGS_PATH}) ]]; then
-  echo "SFTPgo admin API key already set in NCA settings"
-  $(dirname $0)/view_api_keys.sh
-  exit 0
+if [[ ${1:-} != '--force' ]]; then
+  if [[ ! $(grep "!sftpgo_admin_api_key!" ${SETTINGS_PATH}) ]]; then
+    echo "SFTPgo admin API key already set in NCA settings"
+    $(dirname $0)/view_api_keys.sh
+    exit 0
+  fi
 fi
 
 if [[ "${SFTPGO_ADMIN_LOGIN}" == "" ]]; then
@@ -91,7 +93,7 @@ chmod o-rwx ${SETTINGS_PATH}
 
 echo "Writing SFTPgo admin API key to NCA settings file: ${SETTINGS_PATH}"
 # Copy approach needed to work with mounting settings file via Docker
-sed "s/!sftpgo_admin_api_key!/${APIKEY}/" ${SETTINGS_PATH} > /tmp/settings-updated
+sed "s/^SFTPGO_ADMIN_API_KEY=.*$/SFTPGO_ADMIN_API_KEY=${APIKEY}/" ${SETTINGS_PATH} > /tmp/settings-updated
 cp /tmp/settings-updated ${SETTINGS_PATH}
 rm /tmp/settings-updated
 


### PR DESCRIPTION
Adds `--force` flag to `get_admin_api_key.sh` to allow forcibly resetting the API key.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>