### PR TITLE
Fix/alto unprintable unicode

### DIFF
--- a/changelogs/2023-05-03-unicode-fix.md
+++ b/changelogs/2023-05-03-unicode-fix.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Invalid unicode characters (anything defined as a control rune, private-use
+  rune, or "surrogate" rune) are stripped from the output `pdftotext` gives us
+  just prior to generating ALTO XML. This prevents MySQL and MariaDB errors
+  when ingesting into ONI.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/Nerdmaster/magicsql v0.11.0
 	github.com/go-sql-driver/mysql v1.3.0
+	github.com/google/go-cmp v0.3.1
 	github.com/gorilla/mux v1.7.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/uoregon-libraries/gopkg v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/Nerdmaster/magicsql v0.11.0/go.mod h1:VSxpxLy7SnfHjqM6B9LoO8GukliXLyH
 github.com/go-sql-driver/mysql v1.3.0 h1:pgwjLi/dvffoP9aabwkT3AKpXQM93QARkjFhDDqC1UE=
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=

--- a/src/derivatives/alto/pdf_to_alto.go
+++ b/src/derivatives/alto/pdf_to_alto.go
@@ -6,16 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 
 	"github.com/uoregon-libraries/gopkg/fileutil"
 	ltype "github.com/uoregon-libraries/gopkg/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/shell"
 )
-
-// lowASCIIRegex strips all low-ASCII that isn't printable
-var lowASCIIRegex = regexp.MustCompile(`[\x00-\x08\x0b\x0c\x0e-\x1f]`)
 
 // Transformer holds onto various data needed to convert a PDF into
 // ALTO-compatible XML, halting the process at the first error
@@ -122,7 +118,6 @@ func (t *Transformer) extractDoc() {
 	var start = bytes.Index(t.html, []byte("<doc>"))
 	var end = bytes.Index(t.html, []byte("</doc>"))
 	t.html = t.html[start : end+6]
-	t.html = lowASCIIRegex.ReplaceAllLiteral(t.html, nil)
 }
 
 func (t *Transformer) writeALTOFile() {

--- a/src/derivatives/alto/pdftotext.go
+++ b/src/derivatives/alto/pdftotext.go
@@ -4,6 +4,7 @@
 package alto
 
 import (
+	"strings"
 	"unicode"
 )
 
@@ -113,7 +114,7 @@ func (l Line) clean() Line {
 
 	for _, word := range l.Words {
 		var w = word.clean()
-		if w.Text != "" {
+		if strings.TrimSpace(w.Text) != "" {
 			cleaned.Words = append(cleaned.Words, w)
 		}
 	}

--- a/src/derivatives/alto/pdftotext.go
+++ b/src/derivatives/alto/pdftotext.go
@@ -132,9 +132,10 @@ func (w Word) clean() Word {
 	var cleaned = w
 	cleaned.Text = ""
 	for _, r := range []rune(w.Text) {
-		if unicode.IsPrint(r) {
-			cleaned.Text = cleaned.Text + string(r)
+		if unicode.In(r, unicode.Cc, unicode.Co, unicode.Cs) {
+			continue
 		}
+		cleaned.Text = cleaned.Text + string(r)
 	}
 
 	return cleaned

--- a/src/derivatives/alto/pdftotext_test.go
+++ b/src/derivatives/alto/pdftotext_test.go
@@ -1,0 +1,51 @@
+package alto
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDocClean(t *testing.T) {
+	var wd, err = os.Getwd()
+	if err != nil {
+		t.Fatalf("Unable to get working directory: %s", err)
+	}
+
+	var data []byte
+	data, err = os.ReadFile(filepath.Join(wd, "testdata", "test.xml"))
+	if err != nil {
+		t.Fatalf("Unable to read test file: %s", err)
+	}
+
+	var source Doc
+	err = xml.Unmarshal(data, &source)
+	if err != nil {
+		t.Fatalf("Unable to parse test file: %s", err)
+	}
+
+	var cleaned = source.Clean()
+	var cleanedXML []byte
+	cleanedXML, err = xml.MarshalIndent(cleaned, "", "  ")
+	if err != nil {
+		t.Fatalf("Unable to re-marshal XML: %s", err)
+	}
+
+	var expectedXML []byte
+	expectedXML, err = os.ReadFile(filepath.Join(wd, "testdata", "expected.xml"))
+	if err != nil {
+		t.Fatalf("Unable to read test file: %s", err)
+	}
+
+	// vim puts a newline at the end of a file, so we'll inject one into our
+	// cleaned XML for the diff
+	cleanedXML = append(cleanedXML, '\n')
+
+	var diff = cmp.Diff(string(cleanedXML), string(expectedXML))
+	if diff != "" {
+		t.Fatalf(diff)
+	}
+}

--- a/src/derivatives/alto/pdftotext_test.go
+++ b/src/derivatives/alto/pdftotext_test.go
@@ -49,3 +49,38 @@ func TestDocClean(t *testing.T) {
 		t.Fatalf(diff)
 	}
 }
+
+func TestDocCleanWithSoftHyphens(t *testing.T) {
+	var wd, err = os.Getwd()
+	if err != nil {
+		t.Fatalf("Unable to get working directory: %s", err)
+	}
+
+	var data []byte
+	data, err = os.ReadFile(filepath.Join(wd, "testdata", "hyphens.xml"))
+	if err != nil {
+		t.Fatalf("Unable to read test file: %s", err)
+	}
+
+	var source Doc
+	err = xml.Unmarshal(data, &source)
+	if err != nil {
+		t.Fatalf("Unable to parse test file: %s", err)
+	}
+
+	var cleaned = source.Clean()
+	var cleanedXML []byte
+	cleanedXML, err = xml.MarshalIndent(cleaned, "", "  ")
+	if err != nil {
+		t.Fatalf("Unable to re-marshal XML: %s", err)
+	}
+
+	// vim puts a newline at the end of a file, so we'll inject one into our
+	// cleaned XML for the diff
+	cleanedXML = append(cleanedXML, '\n')
+
+	var diff = cmp.Diff(string(cleanedXML), string(data))
+	if diff != "" {
+		t.Fatalf(diff)
+	}
+}

--- a/src/derivatives/alto/testdata/expected.xml
+++ b/src/derivatives/alto/testdata/expected.xml
@@ -1,0 +1,58 @@
+<Doc>
+  <page width="810" height="1026">
+    <flow>
+      <block xMin="587.493" yMin="45.502796" xMax="765.000719" yMax="56.558">
+        <line xMin="587.493" yMin="45.502796" xMax="765.000719" yMax="56.558">
+          <word xMin="682.25084" yMin="45.602" xMax="697.04547" yMax="56.558">July</word>
+          <word xMin="699.161453" yMin="45.602" xMax="710.969199" yMax="56.558">17,</word>
+          <word xMin="713.083034" yMin="45.602" xMax="731.922653" yMax="56.558">2015</word>
+          <word xMin="736.24184" yMin="45.503187" xMax="738.631835" yMax="55.503167">|</word>
+          <word xMin="742.67856" yMin="47.002405" xMax="759.458836" yMax="56.152387">PAGE</word>
+          <word xMin="760.740728" yMin="47.002405" xMax="765.000719" yMax="56.152387">3</word>
+        </line>
+      </block>
+    </flow>
+    <flow>
+      <block xMin="337.796671" yMin="120.933" xMax="472.243108" yMax="479.317">
+        <line xMin="348.598484" yMin="204.933" xMax="472.212325" yMax="215.317">
+          <word xMin="348.598484" yMin="204.933" xMax="365.901971" yMax="215.317">The</word>
+          <word xMin="369.248383" yMin="204.933" xMax="415.875936" yMax="215.317">Southwest</word>
+          <word xMin="419.027499" yMin="204.933" xMax="472.212325" yMax="215.317">Washington</word>
+        </line>
+        <line xMin="337.798484" yMin="216.933" xMax="472.175463" yMax="227.317">
+          <word xMin="337.798484" yMin="216.933" xMax="369.983119" yMax="227.317">Central</word>
+          <word xMin="373.194813" yMin="216.933" xMax="399.330367" yMax="227.317">Labor</word>
+          <word xMin="402.541207" yMin="216.933" xMax="437.177035" yMax="227.317">Council</word>
+          <word xMin="440.390708" yMin="216.933" xMax="454.987203" yMax="227.317">has</word>
+          <word xMin="458.194968" yMin="216.933" xMax="472.175463" yMax="227.317">en-</word>
+        </line>
+        <line xMin="337.798484" yMin="228.933" xMax="472.22225" yMax="239.317">
+          <word xMin="337.798484" yMin="228.933" xMax="369.598489" yMax="239.317">dorsed</word>
+          <word xMin="376.31021" yMin="228.933" xMax="427.21689" yMax="239.317">Ridgefield</word>
+          <word xMin="433.929008" yMin="228.933" xMax="472.22225" yMax="239.317">resident</word>
+        </line>
+        <line xMin="337.798484" yMin="240.933" xMax="450.741469" yMax="251.317">
+          <word xMin="337.798484" yMin="241.307" xMax="368.092259" yMax="251.185">Chuck</word>
+          <word xMin="370.291893" yMin="241.307" xMax="398.542328" yMax="251.185">Green</word>
+          <word xMin="400.742284" yMin="240.933" xMax="413.127952" yMax="251.317">for</word>
+          <word xMin="415.328244" yMin="240.933" xMax="428.332743" yMax="251.317">the</word>
+          <word xMin="430.533425" yMin="240.933" xMax="450.741469" yMax="251.317">post.</word>
+        </line>
+        <line xMin="340.676697" yMin="250.37" xMax="472.230704" yMax="264.791">
+          <word xMin="351.705224" yMin="252.933" xMax="377.479151" yMax="263.317">Green</word>
+          <word xMin="379.895556" yMin="252.933" xMax="386.958704" yMax="263.317">is</word>
+          <word xMin="389.373498" yMin="252.933" xMax="402.267426" yMax="263.317">the</word>
+          <word xMin="404.683758" yMin="252.933" xMax="433.585149" yMax="263.317">project</word>
+          <word xMin="436.003898" yMin="252.933" xMax="472.230704" yMax="263.317">manager</word>
+        </line>
+        <line xMin="337.798624" yMin="264.933" xMax="472.211593" yMax="275.317">
+          <word xMin="337.798624" yMin="264.933" xMax="350.313588" yMax="275.317">for</word>
+          <word xMin="353.348257" yMin="264.933" xMax="390.989699" yMax="275.317">C-Tran’s</word>
+          <word xMin="394.023243" yMin="264.933" xMax="410.827255" yMax="275.317">Bus</word>
+          <word xMin="413.8608" yMin="264.933" xMax="439.51988" yMax="275.317">Rapid</word>
+          <word xMin="442.361677" yMin="264.933" xMax="472.211593" yMax="275.317">Transit</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+</Doc>

--- a/src/derivatives/alto/testdata/hyphens.xml
+++ b/src/derivatives/alto/testdata/hyphens.xml
@@ -1,0 +1,26 @@
+<Doc>
+  <page width="1283.75" height="1769.5">
+    <flow>
+      <block xMin="947.299" yMin="154.992" xMax="1093.107" yMax="199.173">
+        <line xMin="965.299" yMin="154.992" xMax="1093.107" yMax="173.024">
+          <word xMin="965.299" yMin="154.992" xMax="973.203" yMax="173.024">Is</word>
+          <word xMin="977.043" yMin="154.992" xMax="985.379" yMax="173.024">to</word>
+          <word xMin="990.003" yMin="154.992" xMax="1014.339" yMax="173.024">Make</word>
+          <word xMin="1018.547" yMin="154.992" xMax="1056.323" yMax="173.024">Survey*</word>
+          <word xMin="1060.547" yMin="154.992" xMax="1073.379" yMax="173.024">for</word>
+          <word xMin="1077.843" yMin="154.992" xMax="1093.107" yMax="173.024">De­</word>
+        </line>
+        <line xMin="947.299" yMin="167.941" xMax="1070.771" yMax="185.973">
+          <word xMin="947.299" yMin="167.941" xMax="992.563" yMax="185.973">velopment</word>
+          <word xMin="996.691" yMin="167.941" xMax="1005.155" yMax="185.973">of</word>
+          <word xMin="1009.427" yMin="167.941" xMax="1036.563" yMax="185.973">Water</word>
+          <word xMin="1041.827" yMin="167.941" xMax="1070.771" yMax="185.973">P«»w*r</word>
+        </line>
+        <line xMin="976.1" yMin="181.141" xMax="1038.612" yMax="199.173">
+          <word xMin="976.1" yMin="181.141" xMax="986.724" yMax="199.173">on</word>
+          <word xMin="992.9" yMin="181.141" xMax="1038.612" yMax="199.173">McKeaxle.</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+</Doc>

--- a/src/derivatives/alto/testdata/test.xml
+++ b/src/derivatives/alto/testdata/test.xml
@@ -1,0 +1,74 @@
+<Doc>
+  <page width="810.000000" height="1026.000000">
+    <flow>
+      <block xMin="587.493000" yMin="45.502796" xMax="765.000719" yMax="56.558000">
+        <line xMin="587.493000" yMin="45.502796" xMax="765.000719" yMax="56.558000">
+          <word xMin="682.250840" yMin="45.602000" xMax="697.045470" yMax="56.558000">July</word>
+          <word xMin="699.161453" yMin="45.602000" xMax="710.969199" yMax="56.558000">17,</word>
+          <word xMin="713.083034" yMin="45.602000" xMax="731.922653" yMax="56.558000">2015</word>
+          <word xMin="736.241840" yMin="45.503187" xMax="738.631835" yMax="55.503167">|</word>
+          <word xMin="742.678560" yMin="47.002405" xMax="759.458836" yMax="56.152387">PAGE</word>
+          <word xMin="760.740728" yMin="47.002405" xMax="765.000719" yMax="56.152387">3</word>
+        </line>
+      </block>
+    </flow>
+    <flow>
+      <block xMin="337.796671" yMin="120.933000" xMax="472.243108" yMax="479.317000">
+        <line xMin="348.598484" yMin="204.933000" xMax="472.212325" yMax="215.317000">
+          <word xMin="348.598484" yMin="204.933000" xMax="365.901971" yMax="215.317000">The</word>
+          <word xMin="369.248383" yMin="204.933000" xMax="415.875936" yMax="215.317000">Southwest</word>
+          <word xMin="419.027499" yMin="204.933000" xMax="472.212325" yMax="215.317000">Washington</word>
+        </line>
+        <line xMin="337.798484" yMin="216.933000" xMax="472.175463" yMax="227.317000">
+          <word xMin="337.798484" yMin="216.933000" xMax="369.983119" yMax="227.317000">Central</word>
+          <word xMin="373.194813" yMin="216.933000" xMax="399.330367" yMax="227.317000">Labor</word>
+          <word xMin="402.541207" yMin="216.933000" xMax="437.177035" yMax="227.317000">Council</word>
+          <word xMin="440.390708" yMin="216.933000" xMax="454.987203" yMax="227.317000">has</word>
+          <word xMin="458.194968" yMin="216.933000" xMax="472.175463" yMax="227.317000">en-</word>
+        </line>
+        <line xMin="337.798484" yMin="228.933000" xMax="472.222250" yMax="239.317000">
+          <word xMin="337.798484" yMin="228.933000" xMax="369.598489" yMax="239.317000">dorsed</word>
+          <word xMin="376.310210" yMin="228.933000" xMax="427.216890" yMax="239.317000">Ridgefield</word>
+          <word xMin="433.929008" yMin="228.933000" xMax="472.222250" yMax="239.317000">resident</word>
+        </line>
+        <line xMin="337.798484" yMin="240.933000" xMax="450.741469" yMax="251.317000">
+          <word xMin="337.798484" yMin="241.307000" xMax="368.092259" yMax="251.185000">Chuck</word>
+          <word xMin="370.291893" yMin="241.307000" xMax="398.542328" yMax="251.185000">Green</word>
+          <word xMin="400.742284" yMin="240.933000" xMax="413.127952" yMax="251.317000">for</word>
+          <word xMin="415.328244" yMin="240.933000" xMax="428.332743" yMax="251.317000">the</word>
+          <word xMin="430.533425" yMin="240.933000" xMax="450.741469" yMax="251.317000">post.</word>
+        </line>
+        <line xMin="340.676697" yMin="250.370000" xMax="472.230704" yMax="264.791000">
+          <word xMin="340.676697" yMin="250.370000" xMax="340.676697" yMax="264.791000">􏰎</word>
+          <word xMin="341.777480" yMin="250.370000" xMax="341.777480" yMax="264.791000">􏰎</word>
+          <word xMin="342.982951" yMin="250.370000" xMax="342.982951" yMax="264.791000">􏰎</word>
+          <word xMin="344.189987" yMin="250.370000" xMax="344.189987" yMax="264.791000">􏰎</word>
+          <word xMin="345.297798" yMin="250.370000" xMax="345.297798" yMax="264.791000">􏰎</word>
+          <word xMin="346.398581" yMin="250.370000" xMax="346.398581" yMax="264.791000">􏰎</word>
+          <word xMin="347.718896" yMin="250.370000" xMax="347.718896" yMax="264.791000">􏰎</word>
+          <word xMin="351.705224" yMin="252.933000" xMax="377.479151" yMax="263.317000">Green</word>
+          <word xMin="379.895556" yMin="252.933000" xMax="386.958704" yMax="263.317000">is</word>
+          <word xMin="389.373498" yMin="252.933000" xMax="402.267426" yMax="263.317000">the</word>
+          <word xMin="404.683758" yMin="252.933000" xMax="433.585149" yMax="263.317000">project</word>
+          <word xMin="436.003898" yMin="252.933000" xMax="472.230704" yMax="263.317000">manager</word>
+        </line>
+        <line xMin="337.798624" yMin="264.933000" xMax="472.211593" yMax="275.317000">
+          <word xMin="337.798624" yMin="264.933000" xMax="350.313588" yMax="275.317000">for</word>
+          <word xMin="353.348257" yMin="264.933000" xMax="390.989699" yMax="275.317000">C-Tran’s</word>
+          <word xMin="394.023243" yMin="264.933000" xMax="410.827255" yMax="275.317000">Bus</word>
+          <word xMin="413.860800" yMin="264.933000" xMax="439.519880" yMax="275.317000">Rapid</word>
+          <word xMin="442.361677" yMin="264.933000" xMax="472.211593" yMax="275.317000">Transit</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+  <page width="810.000000" height="1026.000000">
+    <flow>
+      <block xMin="587.493000" yMin="45.502796" xMax="765.000719" yMax="56.558000">
+        <line xMin="337.798624" yMin="264.933000" xMax="472.211593" yMax="275.317000">
+          <word xMin="344.189987" yMin="250.370000" xMax="344.189987" yMax="264.791000">􏰎</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+</Doc>

--- a/src/derivatives/alto/transform.go
+++ b/src/derivatives/alto/transform.go
@@ -5,6 +5,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"html/template"
+	"unicode"
+	"unicode/utf8"
 )
 
 // templateVars is used to inject data into the ALTO XML template
@@ -31,9 +33,21 @@ func (t *Transformer) transform() {
 
 	t.Logger.Infof("Converting pdftotext HTML to ALTO XML")
 
+	// Pre-strip any super-busted runes (control characters and invalid runes)
+	var cleaned []byte
+	var offset int
+	for offset < len(t.html) {
+		var r, w = utf8.DecodeRune(t.html[offset:])
+		offset += w
+		if r == utf8.RuneError || unicode.IsControl(r) {
+			continue
+		}
+		cleaned = utf8.AppendRune(cleaned, r)
+	}
+
 	// Parse XML to get at page attributes
 	var source Doc
-	var err = xml.Unmarshal(t.html, &source)
+	var err = xml.Unmarshal(cleaned, &source)
 	if err != nil {
 		t.err = fmt.Errorf("invalid html to unmarshal into XML: %w", err)
 		return

--- a/src/derivatives/alto/transform.go
+++ b/src/derivatives/alto/transform.go
@@ -32,12 +32,15 @@ func (t *Transformer) transform() {
 	t.Logger.Infof("Converting pdftotext HTML to ALTO XML")
 
 	// Parse XML to get at page attributes
-	var html Doc
-	var err = xml.Unmarshal(t.html, &html)
+	var source Doc
+	var err = xml.Unmarshal(t.html, &source)
 	if err != nil {
 		t.err = fmt.Errorf("invalid html to unmarshal into XML: %w", err)
 		return
 	}
+
+	// Fix all "word" elements to avoid non-printable runes
+	var html = source.Clean()
 
 	// Set up template vars
 	var blockNum int

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,4 +1,4 @@
-/sources
+/sources*
 /fakemount
 fakemount.tar
 nca.tgz

--- a/test/README.md
+++ b/test/README.md
@@ -50,6 +50,13 @@ Examples:
   Bohemia Nugget*, using the MARC org code representing "University of Oregon
   Libraries".
 
+### Want A Subset?
+
+The `test/` directory ignores anything below it beginning with "sources", so if
+you want, you could have a huge list of source issues in something like
+"sources-all", and just copy in a subset of issues when you are testing a
+specific situation. This will make the ingest and curation a lot faster.
+
 ## Ingest Sources
 
 The easiest way to blow away the database and get the data started ingesting is


### PR DESCRIPTION
Closes #245 

Strips unprintable unicode out of the ALTO XML. Also adds a bit of testing to validate this fix.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>