### PR TITLE
jobs: make derivative jobs have fewer retries

### DIFF
--- a/changelogs/2023-05-04-derivative-fail-faster.md
+++ b/changelogs/2023-05-04-derivative-fail-faster.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Derivative-generating jobs now fail after only 4 retries (5 tries total)
+  instead of 25 (26 total). Failures with these jobs are almost always fatal,
+  and we want them out of NCA sooner in order to fix the underlying problems
+  manually (e.g., a corrupt PDF).

--- a/src/jobs/jobs.go
+++ b/src/jobs/jobs.go
@@ -23,8 +23,14 @@ func DBJobToProcessor(dbJob *models.Job) Processor {
 		return &IgnoreIssue{IssueJob: NewIssueJob(dbJob)}
 	case models.JobTypePageSplit:
 		return &PageSplit{IssueJob: NewIssueJob(dbJob)}
+
+	// Derivative jobs need a custom maxRetries value since failures are almost
+	// always fatal here (bad version of poppler, broken PDF, etc.)
 	case models.JobTypeMakeDerivatives:
-		return &MakeDerivatives{IssueJob: NewIssueJob(dbJob)}
+		var j = &MakeDerivatives{IssueJob: NewIssueJob(dbJob)}
+		j.maxRetries = 4
+		return j
+
 	case models.JobTypeMoveDerivatives:
 		return &MoveDerivatives{IssueJob: NewIssueJob(dbJob)}
 	case models.JobTypeBuildMETS:


### PR DESCRIPTION
This is a way to hopefully get busted PDFs / TIFFs out of the system sooner by having them fail a *whole lot* sooner. They only get 4 retries now instead of 25, which means a few minutes instead of a couple weeks of retrying the jobs.

This is a tangentially related to #210, but more generally just fixes an annoying problem: most derivative failures are fatal - bad PDFs, bad TIFFs, busted versions of tools, etc. Getting derivative failures into a "final" state sooner means cleaning them up and diagnosing the problem sooner.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>