### PR TITLE
Fix/set statuses before queueing jobs

### DIFF
--- a/changelogs/2023-05-05-job-statuses.md
+++ b/changelogs/2023-05-05-job-statuses.md
@@ -1,0 +1,26 @@
+### Fixed
+
+- All issue- and batch-specific jobs are first setting the object's state and
+  saving it, and only on success queueing up jobs. This fixes rare issues where
+  a slow or dead job runner would allow a user to try to take action on an
+  issue/batch that was already scheduled to have a different action taken.
+  Rare, but disastrous.
+
+### Added
+
+- More in-depth documentation and recipes for manual testing. (See the `test/`
+  directory's `README.md`)
+- A new job type for canceling other jobs. This is strictly for purging jobs
+  that failed permanently, or were on hold waiting for a failed job. This kind
+  of job will be created by `purge-dead-issues` now.
+
+### Changed
+
+- The `jobs` package no longer exposes a bunch of low-level functionality so
+  that the app as a whole is more predictable. Nothing outside `jobs` can just
+  toss random jobs into a queue without creating a high-level function.
+- The `purge-dead-issues` command:
+  - Delegates all job creation and processing to `jobs` rather than having some
+    job-processor calls and some immediate calls to make changes.
+  - *No longer does a dry run*, and this is no longer even an option.
+  - No longer generates a JSON report of what occurred.

--- a/hugo/content/contributing/dev-howto/add-job-types.md
+++ b/hugo/content/contributing/dev-howto/add-job-types.md
@@ -12,23 +12,21 @@ properly in order to ensure it is used, set up, and processed by NCA.
   as `JobTypeRenameDir`.
   - Read and make sure you understand *all structs* in `src/jobs` that
     implement `Process`
-- Create a new `JobType` in [`src/models/job.go`](https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/models/job.go).
+- Create a new `JobType` in [`src/models/job.go`][1].
   - Add the `JobType` to the const list
     - Make sure the string is 100% unique within that list!
   - Add the new `JobType` to the `ValidJobTypes` list
 - Create a new struct that implements the `Process` method.
-  - Use an existing Go file if it makes sense (e.g., another metadata or filesystem job) or
-    create a new one in `src/jobs/`.
+  - Use an existing Go file if it makes sense (e.g., another metadata or
+    filesystem job) or create a new one in `src/jobs/`.
   - Make sure you document the type!  What is its purpose?
   - Need an example?  The metadata jobs are very simple and can be found in
-    [`src/jobs/metadata_jobs.go`](https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/jobs/metadata_jobs.go).
+    [`src/jobs/metadata_jobs.go`][2].
 - Wire up the `JobType` to the concrete `Process` implementor
-  - This is done in
-    [`src/jobs/jobs.go`](https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/jobs/jobs.go),
-    in the `DBJobToProcessor` function
+  - This is done in [`src/jobs/jobs.go`][3], in the `DBJobToProcessor` function
 - Queue a job of the new type.
-  - See [`src/jobs/queue.go`](https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/jobs/queue.go)
-  - You might create a new `Prepare...Job` function, or simply use an existing
+  - See [`src/jobs/queue.go`][4]
+  - You might create a new `prepare...Job` function, or simply use an existing
     one with the new type
   - You might need to create a new arg value, like `srcArg`, `forcedArg`, etc.
     for the processor to use
@@ -36,6 +34,12 @@ properly in order to ensure it is used, set up, and processed by NCA.
     Typically this happens in a `Queue...` function.
 - Make something run jobs of the new type.
   - For almost any new job, you'll just add the type to an existing runner
-    function in [`src/cmd/run-jobs/main.go`](https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/cmd/run-jobs/main.go)
-    (`runAllQueues`).  This ensures a simple job runner invocation (with the
-    `watchall` argument) will run your new job type.
+    function in [`src/cmd/run-jobs/main.go`][5] (`runAllQueues`).  This ensures
+    a simple job runner invocation (with the `watchall` argument) will run your
+    new job type.
+
+[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/models/job.go>
+[2]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/jobs/metadata_jobs.go>
+[3]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/jobs/jobs.go>
+[4]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/jobs/queue.go>
+[5]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/src/cmd/run-jobs/main.go>

--- a/src/cmd/purge-dead-issues/main.go
+++ b/src/cmd/purge-dead-issues/main.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 
-	"github.com/Nerdmaster/magicsql"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cli"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
@@ -16,14 +13,6 @@ import (
 
 var opts cli.BaseOptions
 
-// Stupid error wrapper to make it easy to know if an issue's inability to
-// purge was something critical like a database failure or just an issue that
-// didn't meet the criteria
-type fatalError struct {
-	error
-}
-
-var database *sql.DB
 var erroredIssuesPath string
 
 func getConfig() {
@@ -48,135 +37,69 @@ func main() {
 		logger.Fatalf("Unable to scan database for issues awaiting processing: %s", err)
 	}
 
-	// Set up a transaction so all jobs and issues are processed or skipped as
-	// one operation
-	var op = dbi.DB.Operation()
-	op.Dbg = dbi.Debug
-	op.BeginTransaction()
-	defer op.EndTransaction()
+	purge(issues)
 
-	err = purge(op, issues)
-	if err != nil {
-		logger.Warnf("One or more errors were encountered: aborting transaction")
-		op.Rollback()
-	}
-
-	op.EndTransaction()
-	if op.Err() != nil {
-		logger.Errorf("Failed finalizing purge-jobs' transaction: %s", err)
-	}
 	logger.Debugf("Process complete")
 }
 
-func purge(dbop *magicsql.Operation, list []*models.Issue) error {
+func purge(list []*models.Issue) {
 	for _, i := range list {
 		logger.Debugf("Examining issue id %d (%s)", i.ID, i.HumanName)
-		var err = purgeIssue(dbop, i)
-		if err == nil {
-			logger.Infof("Issue id %d (%s): purged", i.ID, i.HumanName)
+		var ok, err = canPurge(i)
+		if err != nil {
+			logger.Errorf("Error reading data for issue id %d (%s): %s", i.ID, i.HumanName, err)
+			return
+		}
+		if !ok {
+			logger.Infof(`Skipping issue id %d (%s): not in a "dead" state`, i.ID, i.HumanName)
 			continue
 		}
 
-		if errors.As(err, &fatalError{}) {
-			logger.Warnf("Issue id %d (%s): fatal error checking purgability: %s", i.ID, i.HumanName, err)
-			return err
+		err = jobs.QueuePurgeStuckIssue(i, erroredIssuesPath)
+		if err != nil {
+			logger.Errorf("Error queueing issue id %d (%s) for purge: %s", i.ID, i.HumanName, err)
 		}
 
-		logger.Infof("Issue id %d (%s): skipping: %s", i.ID, i.HumanName, err)
+		logger.Infof("Queued issue id %d (%s) for purge", i.ID, i.HumanName)
 	}
-
-	return nil
 }
 
-func purgeIssue(dbop *magicsql.Operation, i *models.Issue) error {
-	if i.BatchID != 0 {
-		return fmt.Errorf("issue is tied to a batch")
-	}
-
+// canPurge tells us if an issue is in need of purging. This is true only if
+// all the following are true of the issue:
+//
+// - It has at least one dead job ("failed", not "failed_done")
+// - It is awaiting processing
+// - It is not tied to a batch
+// - It has no pending jobs still tied to it
+func canPurge(i *models.Issue) (bool, error) {
+	// We validate there are failed jobs first - everything else should be
+	// impossible if there were failed jobs
 	var joblist, err = models.FindJobsForIssueID(i.ID)
 	if err != nil {
-		return &fatalError{err}
+		return false, err
 	}
 
-	var purgeJobs []*models.Job
 	var hasFailedJob bool
 	for _, j := range joblist {
 		switch models.JobStatus(j.Status) {
-		// Jobs on hold / dead need to be closed out; failed jobs specifically get
-		// called out so we know the issue is actually a valid purge candidate
-		// (must have at least one dead job)
 		case models.JobStatusFailed:
 			hasFailedJob = true
-			purgeJobs = append(purgeJobs, j)
-		case models.JobStatusOnHold:
-			purgeJobs = append(purgeJobs, j)
-
-		// These types have no effect on processing and don't need to be dealt with
-		// no matter what else happens
-		case models.JobStatusSuccessful, models.JobStatusFailedDone:
+		case models.JobStatusOnHold, models.JobStatusSuccessful, models.JobStatusFailedDone:
 			continue
-
-		// These job types are blockers for purging an issue, because something
-		// hasn't finished yet
-		case models.JobStatusPending, models.JobStatusInProcess:
-			return fmt.Errorf("cannot purge issue with pending or in-process jobs")
-
-		// Make sure we account for every possible job type
 		default:
-			return fatalError{fmt.Errorf("invalid job status for job %d: %q", j.ID, j.Status)}
+			return false, fmt.Errorf("unexpected data: issue has one or more jobs in a non-purgable status")
 		}
 	}
-
 	if !hasFailedJob {
-		return fmt.Errorf("cannot purge issue with no dead jobs")
+		return false, nil
 	}
 
-	// Getting here means no errors, so we can kick off the purge.  All errors
-	// from doPurge are fatal.
-	err = doPurge(dbop, i, purgeJobs)
-	if err != nil {
-		err = fatalError{err}
+	if i.WorkflowStep != schema.WSAwaitingProcessing {
+		return false, fmt.Errorf("unexpected data: issue is not awaiting processing")
+	}
+	if i.BatchID != 0 {
+		return false, fmt.Errorf("unexpected data: issue is tied to a batch")
 	}
 
-	return err
-}
-
-// doPurge finalizes the dead/on-hold jobs' statuses and then kicks off a new
-// job to remove the issue using the existing QueueRemoveErroredIssue task.
-func doPurge(dbop *magicsql.Operation, issue *models.Issue, purgeJobs []*models.Job) error {
-	var purgeReason = "Issue failed getting through workflow:\n"
-	for _, j := range purgeJobs {
-		logger.Debugf("Canceling job id %d (%s)", j.ID, j.Type)
-		if j.Status == string(models.JobStatusFailed) {
-			purgeReason += fmt.Sprintf("- Job %d (%s) failed too many times\n", j.ID, j.Type)
-		}
-
-		var err = cancelJob(dbop, j)
-		if err != nil {
-			return err
-		}
-	}
-
-	issue.SaveOp(dbop, models.ActionTypeInternalProcess, models.SystemUser.ID, purgeReason)
-	var joblist = jobs.GetJobsForRemoveErroredIssue(issue, erroredIssuesPath)
-	var err = jobs.QueueSerialOp(dbop, joblist...)
-	if err != nil {
-		return fmt.Errorf("queueing jobs to purge issue %d: %w", issue.ID, err)
-	}
-
-	return nil
-}
-
-// cancelJob deals with changing a job's status to failed_done while
-// guarding against accidental purge-jobs
-func cancelJob(dbop *magicsql.Operation, job *models.Job) error {
-	switch models.JobStatus(job.Status) {
-	case models.JobStatusOnHold, models.JobStatusFailed:
-		job.Status = string(models.JobStatusFailedDone)
-		job.SaveOp(dbop)
-		return nil
-
-	default:
-		return fmt.Errorf("invalid job status for job id %d: %q", job.ID, job.Status)
-	}
+	return true, nil
 }

--- a/src/cmd/purge-dead-issues/main.go
+++ b/src/cmd/purge-dead-issues/main.go
@@ -14,12 +14,6 @@ import (
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
 )
 
-const csi = "\033["
-const ansiReset = csi + "0m"
-const ansiBold = csi + "1m"
-const ansiIntenseGreen = csi + "32;1m"
-const ansiIntenseRed = csi + "31;1m"
-
 // Command-line options
 type _opts struct {
 	cli.BaseOptions

--- a/src/cmd/purge-dead-issues/main.go
+++ b/src/cmd/purge-dead-issues/main.go
@@ -14,11 +14,7 @@ import (
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
 )
 
-// Command-line options
-type _opts struct {
-	cli.BaseOptions
-	Live bool `long:"live" description:"Run the issue purge operation rather than just showing what would be done"`
-}
+var opts cli.BaseOptions
 
 // Stupid error wrapper to make it easy to know if an issue's inability to
 // purge was something critical like a database failure or just an issue that
@@ -27,7 +23,6 @@ type fatalError struct {
 	error
 }
 
-var opts _opts
 var database *sql.DB
 var erroredIssuesPath string
 
@@ -63,11 +58,6 @@ func main() {
 	err = purge(op, issues)
 	if err != nil {
 		logger.Warnf("One or more errors were encountered: aborting transaction")
-		op.Rollback()
-	}
-
-	if !opts.Live {
-		logger.Warnf("DRY RUN: aborting transaction")
 		op.Rollback()
 	}
 

--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -384,6 +384,7 @@ func runAllQueues(c *config.Config) {
 				models.JobTypeSetBatchStatus,
 				models.JobTypeSetBatchLocation,
 				models.JobTypeIssueAction,
+				models.JobTypeCancelJob,
 			)
 			addRunner(r)
 			r.Watch(time.Second * 1)

--- a/src/jobs/job_job.go
+++ b/src/jobs/job_job.go
@@ -1,0 +1,44 @@
+package jobs
+
+import (
+	"fmt"
+
+	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
+)
+
+// JobJob wraps the Job type to add things needed in jobs which target *other*
+// jobs. Confusing.
+type JobJob struct {
+	*Job
+	TargetJob *models.Job
+}
+
+// NewJobJob setups up a JobJob from a database Job, centralizing the common
+// validations and data manipulation
+func NewJobJob(dbJob *models.Job) *JobJob {
+	var j, err = newJobJob(dbJob)
+	if err != nil {
+		logger.Criticalf("Unable to create job-targeting job %d: %s", dbJob.ID, err)
+	}
+
+	return j
+}
+
+// newJobJob actually creates the job and returns it and possibly an error
+func newJobJob(dbJob *models.Job) (j *JobJob, err error) {
+	j = &JobJob{Job: NewJob(dbJob)}
+	j.TargetJob, err = models.FindJob(dbJob.ObjectID)
+	if err != nil {
+		return j, err
+	}
+	if j.TargetJob == nil {
+		return j, fmt.Errorf("job id %d does not exist", dbJob.ObjectID)
+	}
+	return j, err
+}
+
+// Valid returns true if the job has a target job
+func (j *JobJob) Valid() bool {
+	return j.TargetJob != nil
+}

--- a/src/jobs/jobs.go
+++ b/src/jobs/jobs.go
@@ -67,6 +67,8 @@ func DBJobToProcessor(dbJob *models.Job) Processor {
 		return &RenumberPages{IssueJob: NewIssueJob(dbJob)}
 	case models.JobTypeIssueAction:
 		return &RecordIssueAction{IssueJob: NewIssueJob(dbJob)}
+	case models.JobTypeCancelJob:
+		return &CancelJob{JobJob: NewJobJob(dbJob)}
 	default:
 		logger.Errorf("Unknown job type %q for job id %d", dbJob.Type, dbJob.ID)
 	}

--- a/src/jobs/metadata_jobs.go
+++ b/src/jobs/metadata_jobs.go
@@ -161,7 +161,7 @@ type CancelJob struct {
 // guarding against canceling jobs which should still stay as-is.
 func (j *CancelJob) Process(*config.Config) bool {
 	var js = models.JobStatus(j.TargetJob.Status)
-	if js != models.JobStatusOnHold || js != models.JobStatusFailedDone {
+	if js != models.JobStatusOnHold && js != models.JobStatusFailedDone {
 		j.Logger.Errorf("Cannot cancel job id %d: invalid job status (%q)", j.TargetJob.ID, j.TargetJob.Status)
 		return false
 	}

--- a/src/jobs/metadata_jobs.go
+++ b/src/jobs/metadata_jobs.go
@@ -161,7 +161,7 @@ type CancelJob struct {
 // guarding against canceling jobs which should still stay as-is.
 func (j *CancelJob) Process(*config.Config) bool {
 	var js = models.JobStatus(j.TargetJob.Status)
-	if js != models.JobStatusOnHold && js != models.JobStatusFailedDone {
+	if js != models.JobStatusOnHold && js != models.JobStatusFailed {
 		j.Logger.Errorf("Cannot cancel job id %d: invalid job status (%q)", j.TargetJob.ID, j.TargetJob.Status)
 		return false
 	}

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Nerdmaster/magicsql"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/config"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
-	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
 )
@@ -37,11 +36,6 @@ func prepareJobAdvanced(t models.JobType, args map[string]string) *models.Job {
 // should queue a specific job ID after completion, should set the WorkflowStep
 // to a custom value rather than whatever the job would normally do, etc.
 func prepareIssueJobAdvanced(t models.JobType, issue *models.Issue, args map[string]string) *models.Job {
-	if issue.WorkflowStep != schema.WSAwaitingProcessing {
-		logger.Fatalf("Preparing issue job %s for issue %s, but issue workflow step is %s",
-			t, issue.Key(), issue.WorkflowStep)
-	}
-
 	var j = prepareJobAdvanced(t, args)
 	j.ObjectID = issue.ID
 	j.ObjectType = models.JobObjectTypeIssue
@@ -50,11 +44,6 @@ func prepareIssueJobAdvanced(t models.JobType, issue *models.Issue, args map[str
 
 // prepareBatchJobAdvanced gets a batch job ready for being used elsewhere
 func prepareBatchJobAdvanced(t models.JobType, batch *models.Batch, args map[string]string) *models.Job {
-	if batch.Status != models.BatchStatusPending {
-		logger.Fatalf("Preparing batch job %s for batch %s, but batch status is %s",
-			t, batch.Name, batch.Status)
-	}
-
 	var j = prepareJobAdvanced(t, args)
 	j.ObjectID = batch.ID
 	j.ObjectType = models.JobObjectTypeBatch

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Nerdmaster/magicsql"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/config"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
 )
@@ -35,6 +36,11 @@ func prepareJobAdvanced(t models.JobType, args map[string]string) *models.Job {
 // should queue a specific job ID after completion, should set the WorkflowStep
 // to a custom value rather than whatever the job would normally do, etc.
 func prepareIssueJobAdvanced(t models.JobType, issue *models.Issue, args map[string]string) *models.Job {
+	if issue.WorkflowStep != schema.WSAwaitingProcessing {
+		logger.Fatalf("Preparing issue job %s for issue %s, but issue workflow step is %s",
+			t, issue.Key(), issue.WorkflowStep)
+	}
+
 	var j = prepareJobAdvanced(t, args)
 	j.ObjectID = issue.ID
 	j.ObjectType = models.JobObjectTypeIssue
@@ -43,6 +49,11 @@ func prepareIssueJobAdvanced(t models.JobType, issue *models.Issue, args map[str
 
 // prepareBatchJobAdvanced gets a batch job ready for being used elsewhere
 func prepareBatchJobAdvanced(t models.JobType, batch *models.Batch, args map[string]string) *models.Job {
+	if batch.Status != models.BatchStatusPending {
+		logger.Fatalf("Preparing batch job %s for batch %s, but batch status is %s",
+			t, batch.Name, batch.Status)
+	}
+
 	var j = prepareJobAdvanced(t, args)
 	j.ObjectID = batch.ID
 	j.ObjectType = models.JobObjectTypeBatch

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -387,10 +387,10 @@ func QueueBatchGoLiveProcess(batch *models.Batch, batchArchivePath string) error
 	}
 
 	var finalPath = filepath.Join(batchArchivePath, batch.FullName())
-	return QueueSerialOp(op,
-		PrepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(batch.Location, finalPath)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(batch.Location)),
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs("")),
-		PrepareBatchJobAdvanced(models.JobTypeMarkBatchLive, batch, nil),
+	return queueSerialOp(op,
+		prepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(batch.Location, finalPath)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(batch.Location)),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs("")),
+		prepareBatchJobAdvanced(models.JobTypeMarkBatchLive, batch, nil),
 	)
 }

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -24,53 +24,53 @@ const (
 	excludeArg = "Exclude"
 )
 
-// PrepareJobAdvanced gets a job of any kind set up with sensible defaults
-func PrepareJobAdvanced(t models.JobType, args map[string]string) *models.Job {
+// prepareJobAdvanced gets a job of any kind set up with sensible defaults
+func prepareJobAdvanced(t models.JobType, args map[string]string) *models.Job {
 	return models.NewJob(t, args)
 }
 
-// PrepareIssueJobAdvanced is a way to get an issue job ready with the
+// prepareIssueJobAdvanced is a way to get an issue job ready with the
 // necessary base values, but not save it immediately, to allow for more
 // advanced job semantics: specifying that the job shouldn't run immediately,
 // should queue a specific job ID after completion, should set the WorkflowStep
 // to a custom value rather than whatever the job would normally do, etc.
-func PrepareIssueJobAdvanced(t models.JobType, issue *models.Issue, args map[string]string) *models.Job {
-	var j = PrepareJobAdvanced(t, args)
+func prepareIssueJobAdvanced(t models.JobType, issue *models.Issue, args map[string]string) *models.Job {
+	var j = prepareJobAdvanced(t, args)
 	j.ObjectID = issue.ID
 	j.ObjectType = models.JobObjectTypeIssue
 	return j
 }
 
-// PrepareBatchJobAdvanced gets a batch job ready for being used elsewhere
-func PrepareBatchJobAdvanced(t models.JobType, batch *models.Batch, args map[string]string) *models.Job {
-	var j = PrepareJobAdvanced(t, args)
+// prepareBatchJobAdvanced gets a batch job ready for being used elsewhere
+func prepareBatchJobAdvanced(t models.JobType, batch *models.Batch, args map[string]string) *models.Job {
+	var j = prepareJobAdvanced(t, args)
 	j.ObjectID = batch.ID
 	j.ObjectType = models.JobObjectTypeBatch
 	return j
 }
 
-// PrepareIssueActionJob sets up a job to record an internal system action tied
+// prepareIssueActionJob sets up a job to record an internal system action tied
 // to the given issue.  This is a very simple wrapper around
-// PrepareIssueJobAdvanced that's meant to make it a lot easier to see whan an
+// prepareIssueJobAdvanced that's meant to make it a lot easier to see whan an
 // action is being recorded.
-func PrepareIssueActionJob(issue *models.Issue, msg string) *models.Job {
-	return PrepareIssueJobAdvanced(models.JobTypeIssueAction, issue, map[string]string{msgArg: msg})
+func prepareIssueActionJob(issue *models.Issue, msg string) *models.Job {
+	return prepareIssueJobAdvanced(models.JobTypeIssueAction, issue, map[string]string{msgArg: msg})
 }
 
-// QueueSerial attempts to save the jobs (in a transaction), setting the first
+// queueSerial attempts to save the jobs (in a transaction), setting the first
 // one as ready to run while the others become effectively dependent on the
 // prior job in the list
-func QueueSerial(jobs ...*models.Job) error {
+func queueSerial(jobs ...*models.Job) error {
 	var op = dbi.DB.Operation()
 	op.BeginTransaction()
 	defer op.EndTransaction()
-	return QueueSerialOp(op, jobs...)
+	return queueSerialOp(op, jobs...)
 }
 
-// QueueSerialOp attempts to save the jobs using an existing operation (for
+// queueSerialOp attempts to save the jobs using an existing operation (for
 // when a transaction needs to wrap more than just the job queueing), but is
-// otherwise the same as QueueSerial.
-func QueueSerialOp(op *magicsql.Operation, jobs ...*models.Job) error {
+// otherwise the same as queueSerial.
+func queueSerialOp(op *magicsql.Operation, jobs ...*models.Job) error {
 	// Iterate over jobs in reverse so we can set the prior job's next-run id
 	// without saving things twice
 	var lastJobID int
@@ -122,38 +122,38 @@ func QueueSFTPIssueMove(issue *models.Issue, c *config.Config) error {
 	var pageReviewWIPDir = filepath.Join(c.PDFPageReviewPath, ".wip-"+issue.HumanName)
 	var backupLoc = filepath.Join(c.PDFBackupPath, issue.HumanName)
 
-	return QueueSerial(
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingProcessing)),
+	return queueSerial(
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingProcessing)),
 
 		// Move the issue to the workflow location
-		PrepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(issue.Location, workflowWIPDir)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.Location)),
-		PrepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(workflowWIPDir, workflowDir)),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(workflowDir)),
+		prepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(issue.Location, workflowWIPDir)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.Location)),
+		prepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(workflowWIPDir, workflowDir)),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(workflowDir)),
 
 		// Clean dotfiles and then kick off the page splitter
-		PrepareJobAdvanced(models.JobTypeCleanFiles, makeLocArgs(workflowDir)),
-		PrepareIssueJobAdvanced(models.JobTypePageSplit, issue, makeLocArgs(workflowWIPDir)),
+		prepareJobAdvanced(models.JobTypeCleanFiles, makeLocArgs(workflowDir)),
+		prepareIssueJobAdvanced(models.JobTypePageSplit, issue, makeLocArgs(workflowWIPDir)),
 
 		// This gets a bit weird.  What's in the issue location dir is the original
 		// upload, which we back up since we may need to reprocess the PDFs from
 		// these originals.  Once we've backed up (syncdir + killdir), we move the
 		// WIP files back into the proper workflow folder...  which is then
 		// promptly moved out to the page review area.
-		PrepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(workflowDir, backupLoc)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(workflowDir)),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueBackupLoc, issue, makeLocArgs(backupLoc)),
-		PrepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(workflowWIPDir, workflowDir)),
+		prepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(workflowDir, backupLoc)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(workflowDir)),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueBackupLoc, issue, makeLocArgs(backupLoc)),
+		prepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(workflowWIPDir, workflowDir)),
 
 		// Now we move the issue data to the page review area for manual
 		// processing, again in multiple idempotent steps
-		PrepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(workflowDir, pageReviewWIPDir)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(workflowDir)),
-		PrepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(pageReviewWIPDir, pageReviewDir)),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(pageReviewDir)),
+		prepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(workflowDir, pageReviewWIPDir)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(workflowDir)),
+		prepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(pageReviewWIPDir, pageReviewDir)),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(pageReviewDir)),
 
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingPageReview)),
-		PrepareIssueActionJob(issue, "Moved issue from SFTP into NCA"),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingPageReview)),
+		prepareIssueActionJob(issue, "Moved issue from SFTP into NCA"),
 	)
 }
 
@@ -163,19 +163,19 @@ func QueueMoveIssueForDerivatives(issue *models.Issue, workflowPath string) erro
 	var workflowDir = filepath.Join(workflowPath, issue.HumanName)
 	var workflowWIPDir = filepath.Join(workflowPath, ".wip-"+issue.HumanName)
 
-	return QueueSerial(
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingProcessing)),
+	return queueSerial(
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingProcessing)),
 
-		PrepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(issue.Location, workflowWIPDir)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.Location)),
-		PrepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(workflowWIPDir, workflowDir)),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(workflowDir)),
+		prepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(issue.Location, workflowWIPDir)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.Location)),
+		prepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(workflowWIPDir, workflowDir)),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(workflowDir)),
 
-		PrepareJobAdvanced(models.JobTypeCleanFiles, makeLocArgs(workflowDir)),
-		PrepareIssueJobAdvanced(models.JobTypeRenumberPages, issue, nil),
-		PrepareIssueJobAdvanced(models.JobTypeMakeDerivatives, issue, nil),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSReadyForMetadataEntry)),
-		PrepareIssueActionJob(issue, "Created issue derivatives"),
+		prepareJobAdvanced(models.JobTypeCleanFiles, makeLocArgs(workflowDir)),
+		prepareIssueJobAdvanced(models.JobTypeRenumberPages, issue, nil),
+		prepareIssueJobAdvanced(models.JobTypeMakeDerivatives, issue, nil),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSReadyForMetadataEntry)),
+		prepareIssueActionJob(issue, "Created issue derivatives"),
 	)
 }
 
@@ -185,12 +185,12 @@ func QueueMoveIssueForDerivatives(issue *models.Issue, workflowPath string) erro
 // completion of the other jobs.
 func QueueForceDerivatives(issue *models.Issue) error {
 	var currentStep = issue.WorkflowStep
-	return QueueSerial(
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingProcessing)),
-		PrepareIssueJobAdvanced(models.JobTypeMakeDerivatives, issue, makeForcedArgs()),
-		PrepareIssueJobAdvanced(models.JobTypeBuildMETS, issue, makeForcedArgs()),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(currentStep)),
-		PrepareIssueActionJob(issue, "Force-regenerated issue derivatives"),
+	return queueSerial(
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSAwaitingProcessing)),
+		prepareIssueJobAdvanced(models.JobTypeMakeDerivatives, issue, makeForcedArgs()),
+		prepareIssueJobAdvanced(models.JobTypeBuildMETS, issue, makeForcedArgs()),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(currentStep)),
+		prepareIssueActionJob(issue, "Force-regenerated issue derivatives"),
 	)
 }
 
@@ -201,18 +201,18 @@ func QueueFinalizeIssue(issue *models.Issue) error {
 	// Some jobs aren't queued up unless there's a backup, so we actually
 	// generate a list of jobs programatically instead of inline
 	var jobs []*models.Job
-	jobs = append(jobs, PrepareIssueJobAdvanced(models.JobTypeBuildMETS, issue, nil))
+	jobs = append(jobs, prepareIssueJobAdvanced(models.JobTypeBuildMETS, issue, nil))
 
 	if issue.BackupLocation != "" {
-		jobs = append(jobs, PrepareIssueJobAdvanced(models.JobTypeArchiveBackups, issue, nil))
-		jobs = append(jobs, PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.BackupLocation)))
-		jobs = append(jobs, PrepareIssueJobAdvanced(models.JobTypeSetIssueBackupLoc, issue, makeLocArgs("")))
+		jobs = append(jobs, prepareIssueJobAdvanced(models.JobTypeArchiveBackups, issue, nil))
+		jobs = append(jobs, prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.BackupLocation)))
+		jobs = append(jobs, prepareIssueJobAdvanced(models.JobTypeSetIssueBackupLoc, issue, makeLocArgs("")))
 	}
 
-	jobs = append(jobs, PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSReadyForBatching)))
-	jobs = append(jobs, PrepareIssueActionJob(issue, "Issue prepped for batching"))
+	jobs = append(jobs, prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSReadyForBatching)))
+	jobs = append(jobs, prepareIssueActionJob(issue, "Issue prepped for batching"))
 
-	return QueueSerial(jobs...)
+	return queueSerial(jobs...)
 }
 
 // QueueMakeBatch sets up the jobs for generating a batch on disk: generating
@@ -221,7 +221,7 @@ func QueueFinalizeIssue(issue *models.Issue) error {
 // Nothing can happen automatically after all this until the batch is verified
 // on staging.
 func QueueMakeBatch(batch *models.Batch, batchOutputPath string) error {
-	return QueueSerial(getJobsForMakeBatch(batch, batchOutputPath)...)
+	return queueSerial(getJobsForMakeBatch(batch, batchOutputPath)...)
 }
 
 // getJobsForMakeBatch returns all jobs needed to generate a batch. This is needed
@@ -230,13 +230,13 @@ func getJobsForMakeBatch(batch *models.Batch, pth string) []*models.Job {
 	var wipDir = filepath.Join(pth, ".wip-"+batch.FullName())
 	var finalDir = filepath.Join(pth, batch.FullName())
 	return []*models.Job{
-		PrepareBatchJobAdvanced(models.JobTypeCreateBatchStructure, batch, makeLocArgs(wipDir)),
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs(wipDir)),
-		PrepareBatchJobAdvanced(models.JobTypeMakeBatchXML, batch, nil),
-		PrepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(wipDir, finalDir)),
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs(finalDir)),
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchStatus, batch, makeBSArgs(models.BatchStatusStagingReady)),
-		PrepareBatchJobAdvanced(models.JobTypeWriteBagitManifest, batch, nil),
+		prepareBatchJobAdvanced(models.JobTypeCreateBatchStructure, batch, makeLocArgs(wipDir)),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs(wipDir)),
+		prepareBatchJobAdvanced(models.JobTypeMakeBatchXML, batch, nil),
+		prepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(wipDir, finalDir)),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs(finalDir)),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchStatus, batch, makeBSArgs(models.BatchStatusStagingReady)),
+		prepareBatchJobAdvanced(models.JobTypeWriteBagitManifest, batch, nil),
 	}
 }
 
@@ -248,13 +248,13 @@ func getJobsForMakeBatch(batch *models.Batch, pth string) []*models.Job {
 // - The original uploads, if relevant, are moved into the error directory
 // - The derivatives are put under a sibling sub-dir from the primary files
 func QueueRemoveErroredIssue(issue *models.Issue, erroredIssueRoot string) error {
-	var jobs = GetJobsForRemoveErroredIssue(issue, erroredIssueRoot)
-	return QueueSerial(jobs...)
+	var jobs = getJobsForRemoveErroredIssue(issue, erroredIssueRoot)
+	return queueSerial(jobs...)
 }
 
-// GetJobsForRemoveErroredIssue returns the list of jobs for removing the given
-// errored issue, suitable for use in a QueueSerial or QueueSerialOp call
-func GetJobsForRemoveErroredIssue(issue *models.Issue, erroredIssueRoot string) []*models.Job {
+// getJobsForRemoveErroredIssue returns the list of jobs for removing the given
+// errored issue, suitable for use in a queueSerial or queueSerialOp call
+func getJobsForRemoveErroredIssue(issue *models.Issue, erroredIssueRoot string) []*models.Job {
 	var dt = time.Now()
 	var dateSubdir = dt.Format("2006-01")
 	var rootDir = filepath.Join(erroredIssueRoot, dateSubdir)
@@ -270,29 +270,29 @@ func GetJobsForRemoveErroredIssue(issue *models.Issue, erroredIssueRoot string) 
 	// move derivative images to the correct subdir so the wip/content dir
 	// consists solely of primary files, and write out the action log file.
 	jobs = append(jobs,
-		PrepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(issue.Location, contentDir)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.Location)),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(contentDir)),
-		PrepareIssueJobAdvanced(models.JobTypeMoveDerivatives, issue, makeLocArgs(derivDir)),
-		PrepareIssueJobAdvanced(models.JobTypeWriteActionLog, issue, nil),
+		prepareJobAdvanced(models.JobTypeSyncDir, makeSrcDstArgs(issue.Location, contentDir)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.Location)),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs(contentDir)),
+		prepareIssueJobAdvanced(models.JobTypeMoveDerivatives, issue, makeLocArgs(derivDir)),
+		prepareIssueJobAdvanced(models.JobTypeWriteActionLog, issue, nil),
 	)
 
 	// If we have a backup, archive it and remove its files
 	if issue.BackupLocation != "" {
 		jobs = append(jobs,
-			PrepareIssueJobAdvanced(models.JobTypeArchiveBackups, issue, nil),
-			PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.BackupLocation)),
-			PrepareIssueJobAdvanced(models.JobTypeSetIssueBackupLoc, issue, makeLocArgs("")),
+			prepareIssueJobAdvanced(models.JobTypeArchiveBackups, issue, nil),
+			prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(issue.BackupLocation)),
+			prepareIssueJobAdvanced(models.JobTypeSetIssueBackupLoc, issue, makeLocArgs("")),
 		)
 	}
 
 	// Move to the final location and update metadata
 	jobs = append(jobs,
-		PrepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(wipDir, finalDir)),
-		PrepareIssueJobAdvanced(models.JobTypeIgnoreIssue, issue, nil),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs("")),
-		PrepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSUnfixableMetadataError)),
-		PrepareIssueActionJob(issue, "Errored issue removed from NCA"),
+		prepareJobAdvanced(models.JobTypeRenameDir, makeSrcDstArgs(wipDir, finalDir)),
+		prepareIssueJobAdvanced(models.JobTypeIgnoreIssue, issue, nil),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueLocation, issue, makeLocArgs("")),
+		prepareIssueJobAdvanced(models.JobTypeSetIssueWS, issue, makeWSArgs(schema.WSUnfixableMetadataError)),
+		prepareIssueActionJob(issue, "Errored issue removed from NCA"),
 	)
 
 	return jobs
@@ -309,9 +309,9 @@ func QueueBatchFinalizeIssueFlagging(batch *models.Batch, flagged []*models.Flag
 	// easily rebuilt metadata (e.g., the bagit info), so this is not truly a
 	// destructive operation
 	jobs = append(jobs,
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchStatus, batch, makeBSArgs(models.BatchStatusPending)),
-		PrepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(batch.Location)),
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs("")),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchStatus, batch, makeBSArgs(models.BatchStatusPending)),
+		prepareJobAdvanced(models.JobTypeKillDir, makeLocArgs(batch.Location)),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchLocation, batch, makeLocArgs("")),
 	)
 
 	// Remove issues one at a time so we can easily resume / restart. Removing an
@@ -327,18 +327,18 @@ func QueueBatchFinalizeIssueFlagging(batch *models.Batch, flagged []*models.Flag
 	// add that level of complexity to job processing.
 	for _, i := range flagged {
 		jobs = append(jobs,
-			PrepareIssueJobAdvanced(models.JobTypeRemoveFile, i.Issue, makeLocArgs(i.Issue.METSFile())),
-			PrepareIssueJobAdvanced(models.JobTypeFinalizeBatchFlaggedIssue, i.Issue, nil),
+			prepareIssueJobAdvanced(models.JobTypeRemoveFile, i.Issue, makeLocArgs(i.Issue.METSFile())),
+			prepareIssueJobAdvanced(models.JobTypeFinalizeBatchFlaggedIssue, i.Issue, nil),
 		)
 	}
 
 	// Remove all the no-longer-useful flagged issue data
-	jobs = append(jobs, PrepareBatchJobAdvanced(models.JobTypeEmptyBatchFlaggedIssuesList, batch, nil))
+	jobs = append(jobs, prepareBatchJobAdvanced(models.JobTypeEmptyBatchFlaggedIssuesList, batch, nil))
 
 	// Regenerate batch
 	jobs = append(jobs, getJobsForMakeBatch(batch, batchOutputPath)...)
 
-	return QueueSerial(jobs...)
+	return queueSerial(jobs...)
 }
 
 // QueueCopyBatchForProduction sets the given batch to pending, then queues up
@@ -363,10 +363,10 @@ func QueueCopyBatchForProduction(batch *models.Batch, prodBatchRoot string) erro
 	var args = makeSrcDstArgs(batch.Location, filepath.Join(prodBatchRoot, batch.FullName()))
 	args[excludeArg] = `*.tif,*.tiff,*.TIF,*.TIFF,*.tar.bz,*.tar`
 
-	return QueueSerialOp(op,
-		PrepareBatchJobAdvanced(models.JobTypeValidateTagManifest, batch, nil),
-		PrepareJobAdvanced(models.JobTypeSyncDir, args),
-		PrepareBatchJobAdvanced(models.JobTypeSetBatchStatus, batch, makeBSArgs(models.BatchStatusPassedQC)),
+	return queueSerialOp(op,
+		prepareBatchJobAdvanced(models.JobTypeValidateTagManifest, batch, nil),
+		prepareJobAdvanced(models.JobTypeSyncDir, args),
+		prepareBatchJobAdvanced(models.JobTypeSetBatchStatus, batch, makeBSArgs(models.BatchStatusPassedQC)),
 	)
 }
 

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -14,6 +14,7 @@ import (
 const (
 	JobObjectTypeBatch = "batch"
 	JobObjectTypeIssue = "issue"
+	JobObjectTypeJob   = "job"
 )
 
 // JobType represents all possible jobs the system queues and processes
@@ -47,6 +48,7 @@ const (
 	JobTypeRemoveFile                  JobType = "remove_file"
 	JobTypeRenumberPages               JobType = "renumber_pages"
 	JobTypeIssueAction                 JobType = "record_issue_action"
+	JobTypeCancelJob                   JobType = "cancel_job"
 )
 
 // ValidJobTypes is the full list of job types which can exist in the jobs
@@ -78,6 +80,7 @@ var ValidJobTypes = []JobType{
 	JobTypeRemoveFile,
 	JobTypeRenumberPages,
 	JobTypeIssueAction,
+	JobTypeCancelJob,
 }
 
 // JobStatus represents the different states in which a job can exist

--- a/test/README.md
+++ b/test/README.md
@@ -138,3 +138,13 @@ approves all issues awaiting metadata review.
 For review, it also queues the job which finalizes the metadata (generating
 METS XML). Once those jobs run, issues will be ready for batching via the
 standard `queue-batches` command.
+
+## Recipes
+
+If you're looking for some test recipes, we now have AT LEAST ONE! And it's
+almost certainly not going to be useful beyond its original use-case!! Wow!
+
+But seriously: in the [recipes subdirectory](./recipes) subdir, we'll start
+putting in any potentially useful tidbits for doing end-to-end tests. These
+will never likely work exactly as written for other situations, but they should
+be a useful guide to help construct your own tests.

--- a/test/recipes/Broken-PDFs.md
+++ b/test/recipes/Broken-PDFs.md
@@ -5,25 +5,11 @@ some critical code related to removal of dead issues. You wouldn't use this
 script precisely as-is, but it should serve as a decent boilerplate for a
 similar kind of test.
 
-*Don't copy and paste this! I put stuff here as I was going, this was never a
-giant script to run non-interactively! Additionally, commands, processes, and
-file locations could change in the future. Consider this recipe a guide, not a
-blind process to run!*
-
-This full process would be repeated entirely: once on the "base" code (in my
-case the `main` branch) and once more on the fixed code.
-
-To wait for jobs to complete, at the moment I just check the database manually:
-
-    select * from jobs where status not in ('success', 'on_hold');
-
-Hopefully we get a UI for viewing jobs one day....
-
 ## Script
 
 ```bash
-# Set an environment variable "name" to "base" or "fix" depending on which run this is
-export name=base
+# Set an environment variable "name" to "baseline" or "fix" depending on which run this is
+export name=baseline
 export name=fix
 
 # Begin
@@ -67,18 +53,6 @@ make clean && make bin/purge-dead-issues && ./bin/purge-dead-issues -c ./setting
 # Run workers one last time
 workers >work.log 2>&1
 
-# Wait for all jobs to complete, then create a report using the "name" variable from above
-cd test
-./report.sh $name
-cd ..
 ```
 
-Compare the two reports to make sure there are no unexpected changes:
-
-```bash
-git add ./test/base-report
-git commit -m "UNDO"
-rm ./test/base-report -rf
-cp -r ./test/fix-report ./test/base-report
-git diff
-```
+Wait for all jobs to complete, then create your report using `$name`.

--- a/test/recipes/Broken-PDFs.md
+++ b/test/recipes/Broken-PDFs.md
@@ -1,0 +1,84 @@
+# Testing Broken PDFs
+
+This was my "script" when testing out how broken PDFs looked when refactoring
+some critical code related to removal of dead issues. You wouldn't use this
+script precisely as-is, but it should serve as a decent boilerplate for a
+similar kind of test.
+
+*Don't copy and paste this! I put stuff here as I was going, this was never a
+giant script to run non-interactively! Additionally, commands, processes, and
+file locations could change in the future. Consider this recipe a guide, not a
+blind process to run!*
+
+This full process would be repeated entirely: once on the "base" code (in my
+case the `main` branch) and once more on the fixed code.
+
+To wait for jobs to complete, at the moment I just check the database manually:
+
+    select * from jobs where status not in ('success', 'on_hold');
+
+Hopefully we get a UI for viewing jobs one day....
+
+## Script
+
+```bash
+# Set an environment variable "name" to "base" or "fix" depending on which run this is
+export name=base
+export name=fix
+
+# Begin
+prep_for_testing >prep.log 2>&1
+
+# Wait until DB is up and start workers
+workers >work.log 2>&1
+
+# Check logs for errors just to be sure things did what we expect
+cat work.log | grep -v " - \(INFO\|DEBUG\) - "
+cat prep.log | grep -v " - \(INFO\|DEBUG\) - "
+
+# Stop workers, save state using the "name" variable from above
+./manage backup 01-$name
+
+# Break two PDF issues
+echo "bad" > ~/projects/work/nca/test/fakemount/page-review/sn88086023-2022080401-**/seq-0026.pdf
+echo "bad" > ~/projects/work/nca/test/fakemount/page-review/2021242619-2020090201-**/seq-0003.pdf
+
+# Renumber and make older
+cd test
+./rename-page-review.sh && ./make-older.sh
+cd ..
+
+# Restart workers, replacing log
+workers >work.log 2>&1
+
+# Wait for jobs to complete and the two failures to finalize (~10min)
+
+# Stop workers, make another backup using the "name" variable from above
+./manage backup 02-$name
+
+# Run the command to purge dead issues (omit "--live" in new fixed branch)
+make clean && make bin/purge-dead-issues && ./bin/purge-dead-issues -c ./settings --live
+
+# Purged issues should include:
+#
+# sn88086023/2022080401
+# 2021242619/2020090201
+
+# Run workers one last time
+workers >work.log 2>&1
+
+# Wait for all jobs to complete, then create a report using the "name" variable from above
+cd test
+./report.sh $name
+cd ..
+```
+
+Compare the two reports to make sure there are no unexpected changes:
+
+```bash
+git add ./test/base-report
+git commit -m "UNDO"
+rm ./test/base-report -rf
+cp -r ./test/fix-report ./test/base-report
+git diff
+```

--- a/test/recipes/General-Test.md
+++ b/test/recipes/General-Test.md
@@ -1,0 +1,49 @@
+# General Testing
+
+This script's purpose is to just run through an end-to-end test starting from
+nothing, faking curation, and generating batches. It's a good starting point
+for building other tests, and an okay test when doing a refactor that may cause
+unexpected changes.
+
+## Script
+
+```bash
+# Begin
+prep_for_testing
+
+# Wait until DB is up and start workers
+workers
+
+# Renumber page review PDFs and hack their date
+cd test
+./rename-page-review.sh && ./make-older.sh
+cd ..
+
+# If necessary, restart workers to make the PDF mover re-read the filesystem quicker
+workers
+
+# Wait for jobs to complete (~10min)
+
+# Stop workers, save state
+./manage backup 01-$name
+
+# Fake-curate, fake-review
+cd test
+go run run-workflow.go -c ../settings --operation curate
+go run run-workflow.go -c ../settings --operation review
+cd ..
+
+# Start workers, wait for jobs to complete (~30sec)
+workers
+
+# Stop workers, save state again
+./manage backup 02-$name
+
+# Generate batches
+./bin/queue-batches -c ./settings
+
+# Start workers, wait for jobs to complete (~30sec)
+workers
+
+# Done!
+```

--- a/test/recipes/README.md
+++ b/test/recipes/README.md
@@ -1,0 +1,51 @@
+# Test Recipes
+
+This directory contains a handful of (hopefully) helpful testing recipes, using
+NCA's manual test workflow. Each document contains an explanation and some
+general information about what's being tested and how it should be used.
+
+At a high level, these test recipes are meant to be used to make sure that a
+new function or refactor doesn't change anything you don't expect it to change,
+so you're generally choosing some kind of baseline to test against, not just
+running the recipe in isolation.
+
+Some general / common information follows.
+
+## Disclaimer
+
+*Don't just copy and paste the shell code!* We're putting stuff in here as we
+go, and sometimes correcting our processes after the fact and trying to keep
+the recipe in sync. Some file locations may be environment-specific.
+Additionally, commands may change or even be removed in the future. Consider
+these recipes a guide, not a blind process to run!
+
+## Names
+
+Each recipe should be run once on your baseline (usually the `main` branch) and
+again on your fixed code. When making snapshots (backing up data state in case
+you need to repeat a step) and reports will need a meaningful name.
+
+Generally it's easiest to do something like `export name=baseline`, then use
+`$name` when you make backups or reports, e.g., `cd test && ./report.sh $name`.
+
+## Repeat And Compare
+
+Again, you'll run the recipe twice: once on your baseline, once on your
+fix/refactor. After each run, you should generate a report. Once you have two
+reports, you can compare them using git. Example:
+
+```bash
+git add ./test/baseline-report
+git commit -m "UNDO"
+rm ./test/baseline-report -rf
+cp -r ./test/fix-report ./test/baseline-report
+git diff
+```
+
+## Waiting for Jobs
+
+To wait for jobs to complete, at the moment I just check the database manually:
+
+    select * from jobs where status not in ('success', 'on_hold');
+
+Hopefully we get a UI for viewing jobs one day....


### PR DESCRIPTION
Closes #210 

Not much to say. See the changelog for details, but this just ensures batches and issues have the right state before kicking off a set of jobs.

I think I spent more time manually testing the refactor, and then fixing problems, than actually doing the implementation.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>