### PR TITLE
Fix/destroy empty batches

### DIFF
--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -385,6 +385,7 @@ func runAllQueues(c *config.Config) {
 				models.JobTypeSetBatchLocation,
 				models.JobTypeIssueAction,
 				models.JobTypeCancelJob,
+				models.JobTypeDeleteBatch,
 			)
 			addRunner(r)
 			r.Watch(time.Second * 1)

--- a/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
+++ b/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
@@ -57,6 +57,7 @@ func prepFlagging(w http.ResponseWriter, req *http.Request) (r *Responder, ok bo
 		return r, false
 	}
 
+	r.Vars.Data["RemainingIssues"] = len(r.issues) - len(r.flaggedIssues)
 	r.Vars.Title = "Rejecting batch " + r.batch.Name
 	return r, true
 }

--- a/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
+++ b/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
@@ -57,15 +57,6 @@ func prepFlagging(w http.ResponseWriter, req *http.Request) (r *Responder, ok bo
 		return r, false
 	}
 
-	var err error
-	r.flaggedIssues, err = r.batch.FlaggedIssues()
-	if err != nil {
-		logger.Criticalf("Error reading flagged issues for batch %d (%s): %s", r.batch.ID, r.batch.Name, err)
-		r.Error(http.StatusInternalServerError, "Error trying to read batch's issues - try again or contact support")
-		return r, false
-	}
-
-	r.Vars.Data["FlaggedIssues"] = r.flaggedIssues
 	r.Vars.Title = "Rejecting batch " + r.batch.Name
 	return r, true
 }

--- a/src/cmd/server/internal/batchhandler/responder.go
+++ b/src/cmd/server/internal/batchhandler/responder.go
@@ -47,6 +47,7 @@ func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, 
 		return r, false
 	}
 
+	r.batch = wrapBatch(b)
 	r.flaggedIssues, err = r.batch.FlaggedIssues()
 	if err != nil {
 		logger.Criticalf("Error reading flagged issues for batch %d (%s): %s", r.batch.ID, r.batch.Name, err)
@@ -61,7 +62,6 @@ func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, 
 	}
 
 	r.Vars.Data["FlaggedIssues"] = r.flaggedIssues
-	r.batch = wrapBatch(b)
 	r.can = Can(r.Vars.User)
 	r.Vars.Data["Batch"] = r.batch
 	r.Vars.Data["Can"] = r.can

--- a/src/cmd/server/internal/batchhandler/responder.go
+++ b/src/cmd/server/internal/batchhandler/responder.go
@@ -18,13 +18,15 @@ type Responder struct {
 	batch *Batch
 	can   *CanValidation
 
-	// This is only set up for some handlers, but when we need it we don't want
-	// to have to re-pull from the database, check errors, etc.
+	// These are only set up for some handlers, but when we need this data we
+	// don't want to have to re-pull from the database, check errors, etc.
 	flaggedIssues []*models.FlaggedIssue
+	issues        []*models.Issue
 }
 
 // getBatchResponder centralizes the most common handler logic where we require
-// a valid batch id in the request
+// a valid batch id in the request, and the flagged and normal issues
+// associated with the batch
 func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, ok bool) {
 	r = &Responder{Responder: responder.Response(w, req)}
 	var idStr = mux.Vars(req)["batch_id"]
@@ -45,6 +47,20 @@ func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, 
 		return r, false
 	}
 
+	r.flaggedIssues, err = r.batch.FlaggedIssues()
+	if err != nil {
+		logger.Criticalf("Error reading flagged issues for batch %d (%s): %s", r.batch.ID, r.batch.Name, err)
+		r.Error(http.StatusInternalServerError, "Error trying to read batch's issues - try again or contact support")
+		return r, false
+	}
+	r.issues, err = r.batch.Issues()
+	if err != nil {
+		logger.Criticalf("Error reading issues for batch %d (%s): %s", r.batch.ID, r.batch.Name, err)
+		r.Error(http.StatusInternalServerError, "Error trying to read batch's issues - try again or contact support")
+		return r, false
+	}
+
+	r.Vars.Data["FlaggedIssues"] = r.flaggedIssues
 	r.batch = wrapBatch(b)
 	r.can = Can(r.Vars.User)
 	r.Vars.Data["Batch"] = r.batch

--- a/src/jobs/batch_flagged_issue_jobs.go
+++ b/src/jobs/batch_flagged_issue_jobs.go
@@ -109,3 +109,19 @@ func (j *EmptyBatchFlaggedIssuesList) Process(*config.Config) bool {
 	}
 	return true
 }
+
+// DeleteBatch removes all issues from a batch and flags it as deleted
+type DeleteBatch struct {
+	*BatchJob
+}
+
+// Process just runs batch.Delete. Easy!
+func (j *DeleteBatch) Process(*config.Config) bool {
+	j.Logger.Debugf("Removing issues and deleting batch %d (%s)", j.DBBatch.ID, j.DBBatch.Name)
+	var err = j.DBBatch.Delete()
+	if err != nil {
+		j.Logger.Errorf("Database error deleting batch: %s", err)
+		return false
+	}
+	return true
+}

--- a/src/jobs/jobs.go
+++ b/src/jobs/jobs.go
@@ -53,6 +53,8 @@ func DBJobToProcessor(dbJob *models.Job) Processor {
 		return &ValidateTagManifest{BatchJob: NewBatchJob(dbJob)}
 	case models.JobTypeMarkBatchLive:
 		return &MarkBatchLive{BatchJob: NewBatchJob(dbJob)}
+	case models.JobTypeDeleteBatch:
+		return &DeleteBatch{BatchJob: NewBatchJob(dbJob)}
 	case models.JobTypeSyncDir:
 		return &SyncDir{Job: NewJob(dbJob)}
 	case models.JobTypeKillDir:

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -41,6 +41,7 @@ const (
 	JobTypeWriteBagitManifest          JobType = "write_bagit_manifest"
 	JobTypeValidateTagManifest         JobType = "validate_tagmanifest"
 	JobTypeMarkBatchLive               JobType = "mark_batch_live"
+	JobTypeDeleteBatch                 JobType = "delete_batch"
 	JobTypeSyncDir                     JobType = "sync_directory"
 	JobTypeKillDir                     JobType = "delete_directory"
 	JobTypeRenameDir                   JobType = "rename_directory"
@@ -73,6 +74,7 @@ var ValidJobTypes = []JobType{
 	JobTypeWriteBagitManifest,
 	JobTypeValidateTagManifest,
 	JobTypeMarkBatchLive,
+	JobTypeDeleteBatch,
 	JobTypeSyncDir,
 	JobTypeKillDir,
 	JobTypeRenameDir,

--- a/templates/batches/flag_issues_form.go.html
+++ b/templates/batches/flag_issues_form.go.html
@@ -84,8 +84,12 @@
             You are about to finalize {{.Data.Batch.Name}}. The
             {{.Data.FlaggedIssues|len}} flagged issue(s) will be removed from
             the batch and put into the "Unfixable Errors" tab in the NCA
-            workflow, then the batch will be rebuilt and pushed up to staging
-            again.
+            workflow, then
+            {{if eq 0 .Data.RemainingIssues}}
+            the batch will be deleted (all issues were flagged for removal).
+            {{else}}
+            the batch will be rebuilt and pushed up to staging again.
+            {{end}}
           </p>
           <button class="btn btn-primary" type="submit" name="action" value="finalize">Confirm</button>
           <button class="btn btn-secondary cta-modal-toggle">Cancel</button>


### PR DESCRIPTION
Closes #228 

- "Finalize" button will now queue up a batch-delete job if every issue in the batch was flagged for removal
- Minor housekeeping with batch handler to make sure all handler funcs are consistently getting the data they need, to avoid panics and implement the new way "finalize" needs to work

As this is a fix to an unreleased feature (4.0 is still not a thing), the normal requirements (changelog, docs) don't really make any sense and are being skipped.