### PR TITLE
Fix/dirsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ Brief description, if necessary
 ### Migration
 -->
 
+## v4.0.1
+
+Hotfix for possible issue that may or may not be in my head.
+
+### Fixed
+
+- This removes the iffy "quiet retry" feature when syncing directories, which
+  is responsible for annoyance and possibly file loss. At best, it's definitely
+  annoying. At worst, it's silencing problems we need to be aware of.
+
 ## v4.0.0
 
 The NCA 4 release fixes and improves a lot of areas, but there are some

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.3.1
 	github.com/gorilla/mux v1.7.0
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/uoregon-libraries/gopkg v0.23.0
+	github.com/uoregon-libraries/gopkg v0.24.0
 	golang.org/x/crypto v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/uoregon-libraries/gopkg v0.23.0 h1:SMKCUgFVyxvfoRyUG7BbVzRIIC/V48xS/I9cy5CAAo0=
-github.com/uoregon-libraries/gopkg v0.23.0/go.mod h1:AQz5Eawxd/FlcIIF1Nan7PVHlxLFSSaF9X+KQhDIvmg=
+github.com/uoregon-libraries/gopkg v0.24.0 h1:UC34AfOJzwTdQo+IHmcolglXuL2reP3fV7AGBfnNteY=
+github.com/uoregon-libraries/gopkg v0.24.0/go.mod h1:AQz5Eawxd/FlcIIF1Nan7PVHlxLFSSaF9X+KQhDIvmg=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=


### PR DESCRIPTION
Hotfix for iffy sync dir retry. Skipping a variety of requirements for PRs here: as a hotfix the changelog was written directly to the main changelog file, and no review is requested as the change is just using a different version of another package.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [ ] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>

## Release deployer

I have done all of the following:

- [ ] Put the contents of `changelogs/*` into `CHANGELOG.md`, rewording as
  necessary
- [ ] Delete `changelogs/*` (not the template of course)
- [ ] Set an appropriate version number in the changelog per semantic
  versioning specs
- [ ] Compiled the hugo documentation and verified very carefully that it is
  correctly generated
- [ ] Tested the code carefully, thoroughly, meticulously, and lovingly. It is
  production-ready.

Once this merges, *I swear on all I hold dear* not to forget any of the
post-deploy steps. I will set up a reminder in Outlook, gmail, via some smart
device, etc.

- [ ] Create and push a tag
- [ ] Create a github release from aforementioned tag, describing the changes
  briefly and linking to the full changelog.
