### PR TITLE
Feature/easier testing xml

### DIFF
--- a/src/derivatives/batchxml/batch_xml.go
+++ b/src/derivatives/batchxml/batch_xml.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"sort"
 
 	"github.com/uoregon-libraries/gopkg/fileutil"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
@@ -45,6 +46,12 @@ func (t *Transformer) Transform() error {
 	if t.err != nil {
 		return t.err
 	}
+
+	// Make sure the issues are sorted in a way that makes them easier to test
+	// and debug
+	sort.Slice(t.d.Issues, func(i, j int) bool {
+		return t.d.Issues[i].Key() < t.d.Issues[j].Key()
+	})
 
 	var buf = new(bytes.Buffer)
 	var err = t.tmpl.Execute(buf, t.d)

--- a/test/report.sh
+++ b/test/report.sh
@@ -40,7 +40,8 @@ for xml in $(find ./fakemount -name "*.xml" | sort); do
   cat $xml | \
     sed 's|<softwareVersion>.*</softwareVersion>|<softwareVersion>XYZZY</softwareVersion>|' | \
     sed 's|<fileName>.*</fileName>|<fileName>XYZZY</fileName>|' | \
-    sed 's|\bID="TB\.[^"]*"|ID="XYZZY"|g' \
+    sed 's|\bID="TB\.[^"]*"|ID="XYZZY"|g' | \
+    sed 's|<metsHdr CREATEDATE="\(....-..-..T\)..:..:..">|<metsHdr CREATEDATE="\100:00:00">|' \
     > $repdir/$fname
 done
 


### PR DESCRIPTION
Enforces batch.xml order and strips times from mets XML - both to facilitate consistency when testing two branches' XML outputs