### PR TITLE
Feature/granular syncdir

### DIFF
--- a/changelogs/2023-07-granular-syncdir.md
+++ b/changelogs/2023-07-granular-syncdir.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- Devs: `test/report.sh` strips more DB ids correctly, making test reporting
+  far easier to scan for real changes
+
+### Changed
+
+- All jobs which were previously `SyncDir` have been split into two:
+  - SyncRecursive is a light-weight, self-replicating job designed to take on
+    the majority of what `SyncDir` used to do. For a given source and
+    destination, all regular files (which don't exist or are a different file
+    size) are copied without any post-copy validation. All directories are
+    aggregated and queued up as new `SyncRecursive` jobs to be run as
+    "siblings" (same priority) in the pipeline.
+  - VerifyRecursive validates the SHA256 hash of every file in the source
+    directory matches that in the destination directory, re-copying any which
+    didn't. This is exatly the same as the prior `SyncDir` job, it just has
+    less work to do since the new `SyncRecursive` job(s) will do the initial
+    copying.
+- Devs: made it so `test/recipes/general-test.sh` is able to "resume" its state
+  to a certain degree, allowing for mistakes to be made when building a complex
+  test up. This pattern should make things easier when time-consuming tasks
+  need to be tested. See the script for details; this is really only important
+  for devs working heavily on the NCA codebase.

--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -345,6 +345,7 @@ func runAllQueues(conf *config.Config) {
 			watchJobTypes(conf,
 				models.JobTypeArchiveBackups,
 				models.JobTypeMoveDerivatives,
+				models.JobTypeSyncRecursive,
 				models.JobTypeVerifyRecursive,
 				models.JobTypeKillDir,
 				models.JobTypeWriteBagitManifest,

--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -345,7 +345,7 @@ func runAllQueues(conf *config.Config) {
 			watchJobTypes(conf,
 				models.JobTypeArchiveBackups,
 				models.JobTypeMoveDerivatives,
-				models.JobTypeSyncDir,
+				models.JobTypeVerifyRecursive,
 				models.JobTypeKillDir,
 				models.JobTypeWriteBagitManifest,
 			)

--- a/src/jobs/jobs.go
+++ b/src/jobs/jobs.go
@@ -57,6 +57,8 @@ func DBJobToProcessor(dbJob *models.Job) Processor {
 		return &MarkBatchLive{BatchJob: NewBatchJob(dbJob)}
 	case models.JobTypeDeleteBatch:
 		return &DeleteBatch{BatchJob: NewBatchJob(dbJob)}
+	case models.JobTypeSyncRecursive:
+		return &SyncRecursive{Job: NewJob(dbJob)}
 	case models.JobTypeVerifyRecursive:
 		return &VerifyRecursive{Job: NewJob(dbJob)}
 	case models.JobTypeKillDir:

--- a/src/jobs/jobs.go
+++ b/src/jobs/jobs.go
@@ -57,8 +57,8 @@ func DBJobToProcessor(dbJob *models.Job) Processor {
 		return &MarkBatchLive{BatchJob: NewBatchJob(dbJob)}
 	case models.JobTypeDeleteBatch:
 		return &DeleteBatch{BatchJob: NewBatchJob(dbJob)}
-	case models.JobTypeSyncDir:
-		return &SyncDir{Job: NewJob(dbJob)}
+	case models.JobTypeVerifyRecursive:
+		return &VerifyRecursive{Job: NewJob(dbJob)}
 	case models.JobTypeKillDir:
 		return &KillDir{Job: NewJob(dbJob)}
 	case models.JobTypeRenameDir:

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -59,6 +59,7 @@ func getJobsForCopyDir(source, destination string, exclusions ...string) []*mode
 	var args = makeSrcDstArgs(source, destination)
 	args[JobArgExclude] = strings.Join(exclusions, ",")
 	return []*models.Job{
+		models.NewJob(models.JobTypeSyncRecursive, args),
 		models.NewJob(models.JobTypeVerifyRecursive, args),
 	}
 }

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -43,7 +43,7 @@ const (
 	JobTypeValidateTagManifest         JobType = "validate_tagmanifest"
 	JobTypeMarkBatchLive               JobType = "mark_batch_live"
 	JobTypeDeleteBatch                 JobType = "delete_batch"
-	JobTypeSyncDir                     JobType = "sync_directory"
+	JobTypeVerifyRecursive             JobType = "verify_recursive"
 	JobTypeKillDir                     JobType = "delete_directory"
 	JobTypeRenameDir                   JobType = "rename_directory"
 	JobTypeCleanFiles                  JobType = "clean_files"
@@ -77,7 +77,7 @@ var ValidJobTypes = []JobType{
 	JobTypeValidateTagManifest,
 	JobTypeMarkBatchLive,
 	JobTypeDeleteBatch,
-	JobTypeSyncDir,
+	JobTypeVerifyRecursive,
 	JobTypeKillDir,
 	JobTypeRenameDir,
 	JobTypeCleanFiles,

--- a/test/README.md
+++ b/test/README.md
@@ -141,10 +141,8 @@ standard `queue-batches` command.
 
 ## Recipes
 
-If you're looking for some test recipes, we now have AT LEAST ONE! And it's
-almost certainly not going to be useful beyond its original use-case!! Wow!
-
-But seriously: in the [recipes subdirectory](./recipes) subdir, we'll start
-putting in any potentially useful tidbits for doing end-to-end tests. These
-will never likely work exactly as written for other situations, but they should
-be a useful guide to help construct your own tests.
+If you're looking for some test recipes, we're slowly building some up in the
+[recipes subdirectory](./recipes), including runnable scripts which automate
+most of the time-consuming testing tasks for specific test cases. These will
+never likely work exactly as written for other situations, but they should be a
+useful guide to help construct your own tests.

--- a/test/report.sh
+++ b/test/report.sh
@@ -20,7 +20,7 @@ sql() {
 }
 
 strip_dbids() {
-  sed 's|\.wip-|XXWIPXX|g' | sed 's|\(..........-..........\)-[0-9]\+|\1|g' | sed 's|\(notouchie-..........\)-[0-9]\+|\1|g'
+  sed 's|\.wip-|XXWIPXX|g' | sed 's|\(..........-..........\)-[0-9]\+|\1|g' | sed 's|\(notouchie-..........\)-[0-9]\+|\1|g' | sed 's|\(split-..........\)-[0-9]\+|\1|g'
 }
 
 repname=${1:-}


### PR DESCRIPTION
Closes #248 

Refactors all directory-sync jobs to be two parts.

The first is a SyncRecursive, a self-replicating job that copies all files it finds, then queues up new jobs for any sub-directories found. If files already exist, SyncRecursive only re-copies if they have a different file size than the source file.

The second part is VerifyRecursive. Its purpose is to do a slow validation of every file that was copied, and to fix any which are missing or don't have the same SHA256 checksum as the original file. This is in fact the old SyncDir job, renamed to VerifyRecursive to make its new role clearer.

In local testing, removal of either job doesn't actually affect the output because whichever job remains gets the copying done, which means we should have good redundancy here. Unfortunately, until we test this with huge amounts of data we won't know how likely the Verify piece is to still overtax the filesystem. Despite being mostly read-only, it's still possible the network filesystem can't handle it. In prior cases where we manually ran rsync in a loop to "catch up", then re-queued the SyncDir job, it was always successful.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>

## Release deployer

I have done all of the following:

- [ ] Put the contents of `changelogs/*` into `CHANGELOG.md`, rewording as
  necessary
- [ ] Delete `changelogs/*` (not the template of course)
- [ ] Set an appropriate version number in the changelog per semantic
  versioning specs
- [ ] Compiled the hugo documentation and verified very carefully that it is
  correctly generated
- [ ] Tested the code carefully, thoroughly, meticulously, and lovingly. It is
  production-ready.

Once this merges, *I swear on all I hold dear* not to forget any of the
post-deploy steps. I will set up a reminder in Outlook, gmail, via some smart
device, etc.

- [ ] Create and push a tag
- [ ] Create a github release from aforementioned tag, describing the changes
  briefly and linking to the full changelog.
