### PR TITLE
Feature/db id refactor

### DIFF
--- a/changelogs/2023-07-db-ids.md
+++ b/changelogs/2023-07-db-ids.md
@@ -1,0 +1,16 @@
+### Changed
+
+- Job logs have been altered to allow for a much larger maximum ID to avoid
+  catastrophic failures in the event one ever reaches ~2 billion entries.
+  Unlikely to happen even in a decade of heavy use, but the new jobs could
+  change that.
+- Jobs were also given more "id space", as the new system spawns a lot more
+  jobs than previously.
+- NCA's codebase has been updated to handle larger IDs in all fields that could
+  ever need them. We aren't updating them all (most could never posssibly reach
+  2 billion), but we're prepared if we need to.
+
+### Migration
+
+- Turn off all NCA processes. Back up your database! Run migrations
+  (`bin/migrate-database`). Start NCA services back up.

--- a/src/cmd/delete-live-done-issues/main.go
+++ b/src/cmd/delete-live-done-issues/main.go
@@ -62,7 +62,7 @@ func warning(issues []*models.Issue) {
 		"  %d issue(s) tied to batches which are 'closed' will be "+
 		ansiIntenseRed+"permanently removed from local disk"+ansiReset+".\n", len(issues))
 
-	var seenBatch = make(map[int]bool)
+	var seenBatch = make(map[int64]bool)
 	var batches []*models.Batch
 	for _, i := range issues {
 		if !seenBatch[i.BatchID] {

--- a/src/cmd/migrate-database/_sql/20230724080000_bigger_id_space.sql
+++ b/src/cmd/migrate-database/_sql/20230724080000_bigger_id_space.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE `jobs` MODIFY COLUMN `id` BIGINT NOT NULL AUTO_INCREMENT UNIQUE;
+ALTER TABLE `jobs` MODIFY COLUMN `object_id` BIGINT NOT NULL;
+ALTER TABLE `job_logs` MODIFY COLUMN `id` BIGINT NOT NULL AUTO_INCREMENT UNIQUE;
+ALTER TABLE `job_logs` MODIFY COLUMN `job_id` BIGINT NOT NULL;
+
+-- +goose Down
+-- SQL in section 'Down' is executed when this migration is rolled back
+ALTER TABLE `job_logs` MODIFY COLUMN `job_id` int(11) NOT NULL;
+ALTER TABLE `job_logs` MODIFY COLUMN `id` int(11) NOT NULL AUTO_INCREMENT;
+ALTER TABLE `jobs` MODIFY COLUMN `object_id` int(11) NOT NULL;
+ALTER TABLE `jobs` MODIFY COLUMN `id` int(11) NOT NULL AUTO_INCREMENT;

--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -202,7 +202,7 @@ func requeue(ids []string) {
 }
 
 func findJob(idString string) *jobs.Job {
-	var id, _ = strconv.Atoi(idString)
+	var id, _ = strconv.ParseInt(idString, 10, 64)
 	if id == 0 {
 		logger.Errorf("Invalid job id %q", idString)
 		return nil

--- a/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
+++ b/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
@@ -128,7 +128,7 @@ func parseIssueKeyStd(val string) (string, error) {
 }
 
 func unflagIssue(r *Responder) {
-	var id, _ = strconv.Atoi(r.Request.Form.Get("issue-id"))
+	var id, _ = strconv.ParseInt(r.Request.Form.Get("issue-id"), 10, 64)
 	if id < 1 {
 		http.SetCookie(r.Writer, &http.Cookie{Name: "Alert", Value: "Invalid issue to unflag", Path: "/"})
 		http.Redirect(r.Writer, r.Request, flagIssuesURL(r.batch), http.StatusBadRequest)

--- a/src/cmd/server/internal/batchhandler/responder.go
+++ b/src/cmd/server/internal/batchhandler/responder.go
@@ -30,7 +30,7 @@ type Responder struct {
 func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, ok bool) {
 	r = &Responder{Responder: responder.Response(w, req)}
 	var idStr = mux.Vars(req)["batch_id"]
-	var id, err = strconv.Atoi(idStr)
+	var id, err = strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		r.Error(http.StatusBadRequest, fmt.Sprintf("Error: %q is not a valid batch id; check your URL and try again", idStr))
 		return r, false

--- a/src/cmd/server/internal/batchhandler/routing.go
+++ b/src/cmd/server/internal/batchhandler/routing.go
@@ -44,7 +44,7 @@ func batchNewsURL(root string, b *Batch) string {
 }
 
 func batchURL(b *Batch, other ...string) string {
-	var parts = []string{basePath, strconv.Itoa(b.ID)}
+	var parts = []string{basePath, strconv.FormatInt(b.ID, 10)}
 	if len(other) > 0 {
 		parts = append(parts, other...)
 	}

--- a/src/cmd/server/internal/issuefinderhandler/schema.go
+++ b/src/cmd/server/internal/issuefinderhandler/schema.go
@@ -46,7 +46,7 @@ func (i *Issue) Link() template.HTML {
 
 	default:
 		contents = "NCA Read-only page viewer"
-		href = path.Join(webutil.FullPath("workflow", strconv.Itoa(i.DatabaseID), "view"))
+		href = path.Join(webutil.FullPath("workflow", strconv.FormatInt(i.DatabaseID, 10), "view"))
 	}
 
 	return template.HTML(fmt.Sprintf(`<a href="%s">%s</a>`, href, contents))

--- a/src/cmd/server/internal/mochandler/handlers.go
+++ b/src/cmd/server/internal/mochandler/handlers.go
@@ -165,7 +165,7 @@ func editHandler(w http.ResponseWriter, req *http.Request) {
 
 func getMOC(r *responder.Responder) (moc *models.MOC, handled bool) {
 	var idStr = r.Request.FormValue("id")
-	var id, _ = strconv.Atoi(idStr)
+	var id, _ = strconv.ParseInt(idStr, 10, 64)
 	if id < 1 {
 		logger.Warnf("Invalid MOC id for request %q (%s)", r.Request.URL.Path, idStr)
 		r.Error(http.StatusBadRequest, "Invalid MOC id - try again or contact support")

--- a/src/cmd/server/internal/responder/templates.go
+++ b/src/cmd/server/internal/responder/templates.go
@@ -162,7 +162,7 @@ func errorHTML(err apperr.Error) template.HTML {
 			href = v.Location[:len(v.Location)-5]
 		} else {
 			// In-process URLs have to be manually crafted
-			href = path.Join(webutil.FullPath("workflow", strconv.Itoa(v.IssueID), "view"))
+			href = path.Join(webutil.FullPath("workflow", strconv.FormatInt(v.IssueID, 10), "view"))
 		}
 		msg += fmt.Sprintf(`: <a href="%s">%s</a>`, href, v.Name)
 	}

--- a/src/cmd/server/internal/titlehandler/handlers.go
+++ b/src/cmd/server/internal/titlehandler/handlers.go
@@ -59,7 +59,7 @@ func Setup(r *mux.Router, baseWebPath string, c *config.Config) {
 
 func getTitle(r *responder.Responder) (t *Title, handled bool) {
 	var idStr = r.Request.FormValue("id")
-	var id, _ = strconv.Atoi(idStr)
+	var id, _ = strconv.ParseInt(idStr, 10, 64)
 	if id < 1 {
 		logger.Warnf("Invalid title id for request %q (%s)", r.Request.URL.Path, idStr)
 		r.Error(http.StatusBadRequest, "Invalid title id - try again or contact support")

--- a/src/cmd/server/internal/userhandler/handlers.go
+++ b/src/cmd/server/internal/userhandler/handlers.go
@@ -55,7 +55,7 @@ func Setup(r *mux.Router, baseWebPath string, c *config.Config) {
 
 func getUserForModify(r *responder.Responder) (u *models.User, handled bool) {
 	var idStr = r.Request.FormValue("id")
-	var id, _ = strconv.Atoi(idStr)
+	var id, _ = strconv.ParseInt(idStr, 10, 64)
 	if id < 1 {
 		logger.Warnf("Invalid user id for request %q (%s)", r.Request.URL.Path, idStr)
 		r.Error(http.StatusBadRequest, "Invalid user id - try again or contact support")

--- a/src/cmd/server/internal/workflowhandler/middleware.go
+++ b/src/cmd/server/internal/workflowhandler/middleware.go
@@ -38,7 +38,8 @@ func handle(h HandlerFunc) http.Handler {
 		// If there's an issue_id parameter, we validate it - unless somebody
 		// deliberately hacks a URL, none of these errors should be very likely
 		if idStr != "" {
-			var id, _ = strconv.Atoi(idStr)
+			var id, _ = strconv.ParseInt(idStr, 10, 64)
+
 			if id == 0 {
 				logger.Warnf("Invalid issue id requested by %s: %s", u.Login, idStr)
 				resp.Vars.Alert = "Invalid issue"

--- a/src/cmd/server/internal/workflowhandler/save_metadata.go
+++ b/src/cmd/server/internal/workflowhandler/save_metadata.go
@@ -43,8 +43,8 @@ func storeIssueMetadata(resp *responder.Responder, i *Issue) map[string]string {
 	// Look for warning ignore/acceptance
 	val = resp.Request.FormValue("ignore_warnings")
 	logger.Warnf("val: %q", val)
-	valNum, _ = strconv.Atoi(val)
-	if valNum == i.ID {
+	var ignoreID, _ = strconv.ParseInt(val, 10, 64)
+	if ignoreID == i.ID {
 		i.acceptWarnings = true
 	}
 

--- a/src/cmd/server/internal/workflowhandler/schema.go
+++ b/src/cmd/server/internal/workflowhandler/schema.go
@@ -154,7 +154,7 @@ func (i *Issue) IsOwned() bool {
 
 // Path returns the path for any basic actions on this issue
 func (i *Issue) Path(actionPath string) string {
-	return path.Join(basePath, strconv.Itoa(i.ID), actionPath)
+	return path.Join(basePath, strconv.FormatInt(i.ID, 10), actionPath)
 }
 
 // ValidateMetadata checks all fields for validity and sets up

--- a/src/cmd/server/internal/workflowhandler/unfixable_error_handlers.go
+++ b/src/cmd/server/internal/workflowhandler/unfixable_error_handlers.go
@@ -74,7 +74,7 @@ func viewRemoveUnfixableFormHandler(resp *responder.Responder, i *Issue) {
 func returnErrorIssueHandler(resp *responder.Responder, i *Issue) {
 	var action = resp.Request.FormValue("action")
 	var comment = resp.Request.FormValue("comment")
-	var wID, _ = strconv.Atoi(resp.Request.FormValue("workflow_owner_id"))
+	var wID, _ = strconv.ParseInt(resp.Request.FormValue("workflow_owner_id"), 10, 64)
 	var err error
 
 	switch action {

--- a/src/jobs/job.go
+++ b/src/jobs/job.go
@@ -74,7 +74,7 @@ func (j *Job) setLogger(level ltype.LogLevel) {
 }
 
 // Find looks up the job in the database and wraps it
-func Find(id int) *Job {
+func Find(id int64) *Job {
 	var dbJob, err = models.FindJob(id)
 	if err != nil {
 		logger.Errorf("Unable to look up job id %d: %s", id, err)

--- a/src/models/action.go
+++ b/src/models/action.go
@@ -66,12 +66,12 @@ func (at ActionType) Describe() string {
 // communication can be centralized in NCA and be easily visible when, for
 // instance, curators need to respond to rejection notes.
 type Action struct {
-	ID         int       `sql:",primary"`
+	ID         int64     `sql:",primary"`
 	CreatedAt  time.Time // When was it created
 	ObjectType string    // "issue" for instance
-	ObjectID   int       // Issue id / batch id / etc
+	ObjectID   int64     // Issue id / batch id / etc
 	ActionType string    // Issue metadata rejection, User comment, etc.
-	UserID     int       // Who created the action
+	UserID     int64     // Who created the action
 	Message    string    // Free-text message
 
 	user *User
@@ -82,7 +82,7 @@ func newAction() *Action {
 }
 
 // NewIssueAction returns an action pre-filled with some basic issue metadata
-func NewIssueAction(id int, aType ActionType) *Action {
+func NewIssueAction(id int64, aType ActionType) *Action {
 	var a = newAction()
 	a.ObjectType = actionObjectTypeIssue
 	a.ActionType = string(aType)
@@ -91,7 +91,7 @@ func NewIssueAction(id int, aType ActionType) *Action {
 	return a
 }
 
-func findActionsByObjectTypeAndID(oType string, oID int) ([]*Action, error) {
+func findActionsByObjectTypeAndID(oType string, oID int64) ([]*Action, error) {
 	var list []*Action
 	var op = dbi.DB.Operation()
 	op.Dbg = dbi.Debug
@@ -105,7 +105,7 @@ func findActionsByObjectTypeAndID(oType string, oID int) ([]*Action, error) {
 
 // FindActionsForIssue returns all actions for the given issue id sorted
 // oldest first
-func FindActionsForIssue(issueID int) ([]*Action, error) {
+func FindActionsForIssue(issueID int64) ([]*Action, error) {
 	return findActionsByObjectTypeAndID(actionObjectTypeIssue, issueID)
 }
 

--- a/src/models/audit_log.go
+++ b/src/models/audit_log.go
@@ -97,7 +97,7 @@ func AuditActionFromString(s string) AuditAction {
 
 // AuditLog represents the audit_logs table
 type AuditLog struct {
-	ID      int       `sql:",primary"`
+	ID      int64     `sql:",primary"`
 	When    time.Time "sql:\"`when`\""
 	IP      string
 	User    string

--- a/src/models/batch.go
+++ b/src/models/batch.go
@@ -115,7 +115,7 @@ var statusMap = map[string]BatchStatus{
 // associated with a single batch, and a batch will typically have many issues
 // assigned to it.
 type Batch struct {
-	ID          int `sql:",primary"`
+	ID          int64 `sql:",primary"`
 	MARCOrgCode string
 	Name        string
 	CreatedAt   time.Time
@@ -157,7 +157,7 @@ func findBatches(where string, args ...any) ([]*Batch, error) {
 }
 
 // FindBatch looks for a batch by its id
-func FindBatch(id int) (*Batch, error) {
+func FindBatch(id int64) (*Batch, error) {
 	var list, err = findBatches("id = ?", id)
 	if len(list) == 0 {
 		return nil, err

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -104,8 +104,8 @@ const (
 
 // JobLog is a single log entry attached to a job
 type JobLog struct {
-	ID        int `sql:",primary"`
-	JobID     int
+	ID        int64 `sql:",primary"`
+	JobID     int64
 	CreatedAt time.Time `sql:",readonly"`
 	LogLevel  string
 	Message   string
@@ -113,15 +113,15 @@ type JobLog struct {
 
 // A Job is anything the app needs to process and track in the background
 type Job struct {
-	ID          int       `sql:",primary"`
+	ID          int64     `sql:",primary"`
 	CreatedAt   time.Time `sql:",readonly"`
 	StartedAt   time.Time `sql:",noinsert"`
 	CompletedAt time.Time `sql:",noinsert"`
 	Type        string    `sql:"job_type"`
-	ObjectID    int
+	ObjectID    int64
 	ObjectType  string
 	Status      string
-	PipelineID  int
+	PipelineID  int64
 	Sequence    int
 	RetryCount  int
 	logs        []*JobLog
@@ -156,7 +156,7 @@ func NewJob(t JobType, args map[string]string) *Job {
 }
 
 // FindJob gets a job by its id
-func FindJob(id int) (*Job, error) {
+func FindJob(id int64) (*Job, error) {
 	var jobs, err = findJobs("id = ?", id)
 	if len(jobs) == 0 {
 		return nil, err

--- a/src/models/moc.go
+++ b/src/models/moc.go
@@ -4,7 +4,7 @@ import "github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
 
 // MOC contains MARC org codes
 type MOC struct {
-	ID   int `sql:",primary"`
+	ID   int64 `sql:",primary"`
 	Code string
 	Name string
 }
@@ -23,7 +23,7 @@ func FindMOCByCode(code string) (*MOC, error) {
 }
 
 // FindMOCByID finds the MOC by its id
-func FindMOCByID(id int) (*MOC, error) {
+func FindMOCByID(id int64) (*MOC, error) {
 	var op = dbi.DB.Operation()
 	op.Dbg = dbi.Debug
 	var moc = &MOC{}

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -43,11 +43,11 @@ const (
 // the same sequence as its creator, ensuring whatever would run next in the
 // sequence has to wait for the new job to run.
 type Pipeline struct {
-	ID          int `sql:",primary"`
+	ID          int64 `sql:",primary"`
 	Name        string
 	Description string
 	ObjectType  string
-	ObjectID    int
+	ObjectID    int64
 	CreatedAt   time.Time `sql:",readonly"`
 	StartedAt   time.Time
 	CompletedAt time.Time
@@ -72,7 +72,7 @@ func findPipelines(where string, args ...any) ([]*Pipeline, error) {
 }
 
 // findPipeline pulls the pipeline object for the given id
-func findPipeline(id int) (*Pipeline, error) {
+func findPipeline(id int64) (*Pipeline, error) {
 	var list, err = findPipelines("id = ?", id)
 	if len(list) == 0 {
 		return nil, err

--- a/src/models/title.go
+++ b/src/models/title.go
@@ -12,7 +12,7 @@ import (
 
 // Title holds records from the titles table
 type Title struct {
-	ID            int `sql:",primary"`
+	ID            int64 `sql:",primary"`
 	Name          string
 	LCCN          string
 	EmbargoPeriod string
@@ -36,7 +36,7 @@ func FindTitle(where string, args ...any) (*Title, error) {
 }
 
 // FindTitleByID wraps FindTitle to simplify basic finding
-func FindTitleByID(id int) (*Title, error) {
+func FindTitleByID(id int64) (*Title, error) {
 	return FindTitle("id = ?", id)
 }
 

--- a/src/models/user.go
+++ b/src/models/user.go
@@ -11,7 +11,7 @@ import (
 
 // User identifies a person who has logged in via Apache's auth
 type User struct {
-	ID          int    `sql:",primary"`
+	ID          int64  `sql:",primary"`
 	Login       string `sql:",noupdate"`
 	RolesString string `sql:"roles"`
 	Guest       bool   `sql:"-"`
@@ -88,7 +88,7 @@ func FindActiveUserWithLogin(l string) *User {
 
 // FindUserByID looks up a user by the given ID - this can return inactive users
 // since it's just using a database ID, so there's no possible ambiguity
-func FindUserByID(id int) *User {
+func FindUserByID(id int64) *User {
 	// Hack to ensure we can just call standard finders to get the system user
 	if id == SystemUser.ID {
 		return SystemUser

--- a/src/schema/issue_errors.go
+++ b/src/schema/issue_errors.go
@@ -99,7 +99,7 @@ func (i *Issue) WarnTooNew() apperr.Error {
 // holds onto extra information for figuring out how to handle the dupe
 type DuplicateIssueError struct {
 	*IssueError
-	IssueID  int
+	IssueID  int64
 	Location string
 	Name     string
 	IsLive   bool

--- a/src/schema/schema.go
+++ b/src/schema/schema.go
@@ -226,7 +226,7 @@ func (list TitleList) Unique() TitleList {
 
 // Issue is an extremely basic encapsulation of an issue's high-level data
 type Issue struct {
-	DatabaseID     int // This will be zero for issues which aren't instantiated from the database conversion
+	DatabaseID     int64 // This will be zero for issues which aren't instantiated from the database conversion
 	MARCOrgCode    string
 	Title          *Title
 	RawDate        string // This is the date as seen on the filesystem when the issue was uploaded


### PR DESCRIPTION
Increases size of job-related ids in the database, and fixes all IDs across NCA to use int64. The code change makes NCA able to handle the BIGINT now in the database for jobs as well as being able to handle any future ids we may change to BIGINT.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
