### PR TITLE
Fix/pages csv

### DIFF
--- a/changelogs/2023-07-31-pages-csv.md
+++ b/changelogs/2023-07-31-pages-csv.md
@@ -1,3 +1,8 @@
 ### Fixed
 
 - Page labeling no longer breaks when a page's label includes a comma
+
+### Migration
+
+- Run database migrations to fix all existing page labels:
+  - `make && ./bin/migrate-database -c ./settings up`

--- a/changelogs/2023-07-31-pages-csv.md
+++ b/changelogs/2023-07-31-pages-csv.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Page labeling no longer breaks when a page's label includes a comma

--- a/src/cmd/migrate-database/_sql/20230731125500_page_label_delimiter.sql
+++ b/src/cmd/migrate-database/_sql/20230731125500_page_label_delimiter.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+UPDATE `issues` SET page_labels_csv = REPLACE(page_labels_csv, ",", "␟");
+
+-- +goose Down
+-- SQL in section 'Down' is executed when this migration is rolled back
+UPDATE `issues` SET page_labels_csv = REPLACE(page_labels_csv, "␟", ",");

--- a/src/models/issue.go
+++ b/src/models/issue.go
@@ -623,14 +623,14 @@ func (i *Issue) SaveOpWithoutAction(op *magicsql.Operation) error {
 
 // serialize prepares struct data to work with the database fields better
 func (i *Issue) serialize() {
-	i.PageLabelsCSV = strings.Join(i.PageLabels, ",")
+	i.PageLabelsCSV = strings.Join(i.PageLabels, "␟")
 	i.WorkflowStepString = string(i.WorkflowStep)
 }
 
 // deserialize performs operations necessary to get the database data into a more
 // useful Go structure
 func (i *Issue) deserialize() {
-	i.PageLabels = strings.Split(i.PageLabelsCSV, ",")
+	i.PageLabels = strings.Split(i.PageLabelsCSV, "␟")
 	i.WorkflowStep = schema.WorkflowStep(i.WorkflowStepString)
 	i.setHumanName()
 }

--- a/static/js/metadata.js
+++ b/static/js/metadata.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
     // Store the page label in the global array
     var currentPage = parseInt($("#osd-image-number").text()) - 1;
     pageLabels[currentPage] = $("#page-label").val();
-    $("#page-labels-csv").val(pageLabels.join(","));
+    $("#page-labels-csv").val(pageLabels.join("␟"));
 
     goToNextUnlabeledPage();
 
@@ -36,7 +36,7 @@ $(document).ready(function() {
   $("#metadata-form").submit(function(e) {
     var currentPage = parseInt($("#osd-image-number").text()) - 1;
     pageLabels[currentPage] = $("#page-label").val();
-    $("#page-labels-csv").val(pageLabels.join(","));
+    $("#page-labels-csv").val(pageLabels.join("␟"));
   });
 
   // Don't validate when saving as a draft


### PR DESCRIPTION
Closes #131 

Uses ascii unit separator (␟) instead of commas. Still not the right solution, but a far safer hack.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>
