### PR TITLE
scripts/localdev.sh: auto-provision sftpgo key

### DIFF
--- a/scripts/localdev.sh
+++ b/scripts/localdev.sh
@@ -85,6 +85,7 @@ upload_server() {
 }
 
 server() {
+  SETTINGS_PATH=$(pwd)/settings ./sftpgo/get_admin_api_key.sh --force >/dev/null
   docker compose up -d db iiif sftpgo
   wait_for_database
   make bin/server || return 1


### PR DESCRIPTION
Force-provisions a new SFTPGo key on *every* `server` invocation. This is unnecessary, but it doesn't hurt anything to have a billion keys generated, especially in local dev situations where the docker volumes for the database and SFTPGo are blown away regularly anyway.

This is a dev-only change that won't affect production.