### PR TITLE
Fix/issue error messages

### DIFF
--- a/changelogs/2023-08-03-issue-error-message.md
+++ b/changelogs/2023-08-03-issue-error-message.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- In the issue upload screen, issues with an invalid folder name no longer
+  cause a flurry of incorrect "This issue appears to be a duplicate..."
+  messages.

--- a/src/schema/searchkey.go
+++ b/src/schema/searchkey.go
@@ -9,7 +9,7 @@ import (
 
 // validKey defines the format for a minimal issue-key-like search
 // string: LCCN, year, month, day, and edition
-var validKey = regexp.MustCompile(`^(\w+)(/\d+)?`)
+var validKey = regexp.MustCompile(`^(\w+)(/\d+)?$`)
 
 // Key defines the precise issue (or subset of issues) we want to
 // find.  Note that the structure here is very specific to this issue finder,

--- a/src/schema/searchkey_test.go
+++ b/src/schema/searchkey_test.go
@@ -58,4 +58,5 @@ func TestPartialSearchKeys(t *testing.T) {
 func TestInvalidSearchKey(t *testing.T) {
 	expectError("Key with bad month", "sn12345678/2000019901", "invalid date", t)
 	expectError("Key with weird date", "sn12345678/2000010001", "invalid date", t)
+	expectError("Key with invalid date format", "sn12345678/A01", "invalid issue key format", t)
 }


### PR DESCRIPTION
Closes #197 

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>