### PR TITLE
schema: fix issue key parsing for dupe-checking

### DIFF
--- a/changelogs/2023-08-15-issuekey.md
+++ b/changelogs/2023-08-15-issuekey.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Issue keys are even more carefully validated when dupe-checking

--- a/src/schema/schema.go
+++ b/src/schema/schema.go
@@ -354,6 +354,21 @@ func (i *Issue) LastModified() time.Time {
 	return t
 }
 
+// SearchKey converts an issue's data to a search key, primarily for
+// dupe-checking. This calls ParseSearchKey, but adds extra checks for the
+// issue having a full set of data, which ParseSearchKey doesn't require.
+func (i *Issue) SearchKey() (*Key, error) {
+	var sKey, err = ParseSearchKey(i.Key())
+	if err != nil {
+		return sKey, err
+	}
+	if sKey.LCCN == "" || sKey.Year == 0 || sKey.Month == 0 || sKey.Day == 0 || sKey.Ed == 0 {
+		err = fmt.Errorf("invalid issue data; cannot generate a search key")
+	}
+
+	return sKey, err
+}
+
 // CheckDupes centralizes the logic for seeing if an issue has a duplicate in a
 // given lookup, adding a duplication error if there is a dupe and that dupe is
 // considered to be more "canonical" than this issue.  e.g., if there's an
@@ -362,7 +377,7 @@ func (i *Issue) LastModified() time.Time {
 func (i *Issue) CheckDupes(lookup *Lookup) {
 	// Get a search key for this issue.  If the issue key is invalid, that
 	// probably means a bad upload, and so dupe-checking doesn't really matter
-	var sKey, err = ParseSearchKey(i.Key())
+	var sKey, err = i.SearchKey()
 	if err != nil {
 		return
 	}
@@ -379,7 +394,7 @@ func (i *Issue) CheckDupes(lookup *Lookup) {
 func (i *Issue) CheckLiveDupes(lookup *Lookup) {
 	// Get a search key for this issue.  If the issue key is invalid, that
 	// probably means a bad upload, and so dupe-checking doesn't really matter
-	var sKey, err = ParseSearchKey(i.Key())
+	var sKey, err = i.SearchKey()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Small change to dupe-checking to further reduce the risk of issues with bad directories giving us weird errors again.

## Normal contributors

I have done all of the following:

- [ ] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [ ] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>