### PR TITLE
Create "purge batch" functionality

### DIFF
--- a/changelogs/2024-02-28-purge-batches.md
+++ b/changelogs/2024-02-28-purge-batches.md
@@ -1,0 +1,5 @@
+### Added
+
+- Batches which fail QC can now be purged entirely, pushing all issues back to
+  NCA so they can be rebatched. Sounds crazy? I thought so, too, until
+  discovering that we had built a batch by mistake.

--- a/src/cmd/server/internal/batchhandler/can.go
+++ b/src/cmd/server/internal/batchhandler/can.go
@@ -81,6 +81,16 @@ func (c *CanValidation) Reject(b *Batch) bool {
 	return b.Status == models.BatchStatusQCReady
 }
 
+// Purge is true if the user is allowed to purge batches, and the batch is
+// ready for issue flagging
+func (c *CanValidation) Purge(b *Batch) bool {
+	if !c.user.PermittedTo(privilege.PurgeBatches) {
+		return false
+	}
+
+	return b.Status == models.BatchStatusQCFlagIssues
+}
+
 // FlagIssues is true if the user can reject in-QC batches and b is ready for
 // issue flagging
 func (c *CanValidation) FlagIssues(b *Batch) bool {

--- a/src/models/action.go
+++ b/src/models/action.go
@@ -33,6 +33,7 @@ const (
 	ActionTypeApproveBatch         ActionType = "approve-batch"
 	ActionTypeRejectBatch          ActionType = "reject-batch"
 	ActionTypeFinalizeBatch        ActionType = "finalize-batch"
+	ActionTypePurgeBatch           ActionType = "purge-batch"
 	ActionTypeAbortBatchRejection  ActionType = "abort-reject-batch"
 	ActionTypeFlagBatchQCReady     ActionType = "flag-batch-qc-ready"
 )
@@ -71,6 +72,8 @@ func (at ActionType) Describe() string {
 		return "returned the batch to QC with no changes"
 	case ActionTypeFinalizeBatch:
 		return "finalized the batch for rebuild after rejecting one or more issues"
+	case ActionTypePurgeBatch:
+		return "purged the batch, moving all issues back to NCA"
 	case ActionTypeFlagBatchQCReady:
 		return "flagged the batch as being ready for QC"
 	default:

--- a/templates/batches/flag_issues_form.go.html
+++ b/templates/batches/flag_issues_form.go.html
@@ -54,13 +54,18 @@
       <button class="btn btn-primary" type="submit">Add Issue To Removal Queue</button>
     </form>
 
-    <h2>Finalize / Cancel</h2>
+    <h2>Finalize / Undo / Abort</h2>
     <p>
       When you're certain you've identified all problem issues, select
       "Finalize" below. <em>This will effectively lock the batch from further
       updates, so be certain you're done!</em>
       {{if not .Data.FlaggedIssues}}<strong>Note: you haven't selected any
       issues yet, so finalizing is not an option.</strong>{{end}}
+    </p>
+    <p>
+      If you just want to remove the batch but leave the issues in NCA for a
+      new batch generation, select "Purge" below. This will finalize flagged
+      issues, but push all the good issues back into NCA and destroy the batch.
     </p>
     <p>
       If this batch doesn't need any issues removed (i.e., it was failed by
@@ -95,6 +100,43 @@
           <button class="btn btn-secondary cta-modal-toggle">Cancel</button>
         </div>
       </cta-modal>
+
+      {{if .Data.Can.Purge .Data.Batch}}
+      <cta-modal>
+        <div slot="button" class="inline">
+          {{if ne 0 .Data.RemainingIssues}}
+          <button class="btn btn-primary cta-modal-toggle">Purge</button>
+          {{else}}
+          <button class="btn btn-disabled" disabled="disabled">Purge</button>
+          {{end}}
+        </div>
+
+        <div slot="modal">
+          <h2>Purge Batch?</h2>
+          <p>
+            You are about to purge {{.Data.Batch.Name}}. The following actions will occur:
+            <ul>
+              <li>
+                The {{.Data.FlaggedIssues|len}} flagged issue(s) will be
+                removed from the batch and put into the "Unfixable Errors" tab
+                in the NCA workflow.
+              </li>
+              <li>
+                All other issues will be moved back to NCA's normal workflow,
+                ready to immediately be included in a new batch.
+              </li>
+              <li>
+                The batch will be purged from disk and from NCA.
+              </li>
+            </ul>
+
+            <i>This is generally not necessary unless the batch was built by mistake</i>.
+          </p>
+          <button class="btn btn-primary" type="submit" name="action" value="purge">Confirm</button>
+          <button class="btn btn-secondary cta-modal-toggle">Cancel</button>
+        </div>
+      </cta-modal>
+      {{end}}
 
       <cta-modal>
         <div slot="button" class="inline">

--- a/templates/batches/view.go.html
+++ b/templates/batches/view.go.html
@@ -45,10 +45,11 @@
     {{else if and .Data.Batch.ReadyForFlaggingIssues (.Data.Can.FlagIssues .Data.Batch)}}
     <p>
       {{.Data.Batch.Name}} has failed QC. You can mark issues that need to be
-      removed and then send the batch back to staging.
+      removed and then send the batch back to staging, or eliminate the batch
+      entirely.
     </p>
 
-    <a href="{{FlagIssuesURL .Data.Batch}}" class="btn btn-primary">Flag Issues...</a>
+    <a href="{{FlagIssuesURL .Data.Batch}}" class="btn btn-primary">Flag Issues / Purge Batch...</a>
 
     <!-- Needs production load -->
     {{else if and .Data.Batch.ReadyForProduction (.Data.Can.Load .Data.Batch)}}


### PR DESCRIPTION
Adds a way to purge batches that failed QC, removing flagged issues while also "pushing" good issues back into NCA for rebatching. This can be handy if a batch was built by mistake or only had a few issues to begin with and you want to wait to rebuild a bigger batch when more issues have finished being curated and reviewed.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>