### PR TITLE
Hotfix/sftpgo user updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,6 @@ Brief description, if necessary
 ### Migration
 -->
 
-## v4.3.2
-
-Hotfix: NCA can now update users in SFTPGo again.
-
-### Fixed
-
-- SFTPGo's 2.5.0 release changed how user updates work. This hotfix makes NCA
-  capable of updating them again.
-
 ## v4.3.1
 
 Batch purging. That's all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ Brief description, if necessary
 ### Migration
 -->
 
+## v4.3.2
+
+Hotfix: NCA can now update users in SFTPGo again.
+
+### Fixed
+
+- SFTPGo's 2.5.0 release changed how user updates work. This hotfix makes NCA
+  capable of updating them again.
+
 ## v4.3.1
 
 Batch purging. That's all.

--- a/changelogs/2024-03-06-sftpgo.md
+++ b/changelogs/2024-03-06-sftpgo.md
@@ -1,9 +1,14 @@
 ### Changed
 
-- Devs: upgraded the docker SFTPGo version to 2.5
+- Upgraded the docker SFTPGo version to 2.5
+- Changed how NCA connects to SFTPGo on user updates to match the way SFTPGo
+  2.5 works. This should be compatible with older SFTPGo versions.
 
 ### Migration
 
+- If you're running an older version of SFTPGo you may have to upgrade to
+  v2.5.0. I expect the NCA changes to be backward-compatible, but I'm not 100%
+  certain.
 - If you have a long-running dev setup for some reason, your SFTPGo database
   won't work with this update. You should generally just be okay to start
   fresh, as the docker setup isn't meant for long-term data storage, but if you

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/mux v1.7.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/pressly/goose/v3 v3.13.4
+	github.com/tidwall/sjson v1.2.5
 	github.com/uoregon-libraries/gopkg v0.24.0
 	golang.org/x/crypto v0.10.0
 	golang.org/x/text v0.11.0
@@ -16,5 +17,8 @@ require (
 
 require (
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
+	github.com/tidwall/gjson v1.17.1 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,16 @@ github.com/pressly/goose/v3 v3.13.4 h1:9xRcg/hEU9HqeRNeKh69VLtPWCKAYTX6l2VsXWOX8
 github.com/pressly/goose/v3 v3.13.4/go.mod h1:Fo8rYaf9tYfQiDpo+ymrnZi8vvLkvguRl16nu7QnUT4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/uoregon-libraries/gopkg v0.24.0 h1:UC34AfOJzwTdQo+IHmcolglXuL2reP3fV7AGBfnNteY=
 github.com/uoregon-libraries/gopkg v0.24.0/go.mod h1:AQz5Eawxd/FlcIIF1Nan7PVHlxLFSSaF9X+KQhDIvmg=
 golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=


### PR DESCRIPTION
Hotfix for SFTPGo server upgrade: user modifications were done incorrectly

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
- [x] @mention individual(s) you would like to review the PR

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>

## Release deployer

I have done all of the following:

- [ ] Put the contents of `changelogs/*` into `CHANGELOG.md`, rewording as
  necessary
- [ ] Delete `changelogs/*` (not the template of course)
- [ ] Set an appropriate version number in the changelog per semantic
  versioning specs
- [ ] Compiled the hugo documentation and verified very carefully that it is
  correctly generated
- [ ] Tested the code carefully, thoroughly, meticulously, and lovingly. It is
  production-ready.

Once this merges, *I swear on all I hold dear* not to forget any of the
post-deploy steps. I will set up a reminder in Outlook, gmail, via some smart
device, etc.

- [ ] Create and push a tag
- [ ] Create a github release from aforementioned tag, describing the changes
  briefly and linking to the full changelog.
