### PR TITLE
Fix/double issue queue

### DIFF
--- a/changelogs/2024-04-01-double-queue.md
+++ b/changelogs/2024-04-01-double-queue.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Uploaded issues can no longer be doubly queued for ingest into NCA


### PR DESCRIPTION
Prevents uploaded issues from being queued twice. Very rare, but apparently it's happened a few times despite the "prevent double submit" javascript.

## Normal contributors

I have done all of the following:

- [ ] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)