### PR TITLE
Add "batch size" flags to the batch queue tool

### DIFF
--- a/changelogs/2024-04-12-batch-cli-flags.md
+++ b/changelogs/2024-04-12-batch-cli-flags.md
@@ -1,0 +1,5 @@
+### Added
+
+- `queue-batches` now optionally takes command-line flags to override the
+  min/max batch size settings. This was done to allow cron jobs that behave
+  differently than a manual run.

--- a/hugo/content/setup/services.md
+++ b/hugo/content/setup/services.md
@@ -98,6 +98,10 @@ your configured `BATCH_OUTPUT_PATH` and syncing to the `BATCH_PRODUCTION_PATH`.
 The batch status page in NCA will show which batches have finished processing
 and are ready for ingest into staging.
 
+The tool can be given flags for `--min-batch-size` and `--max-batch-size` in
+order to override the standard settings, e.g., if you need cronned batch
+generation to behave differently than manual runs.
+
 ## Bulk Upload Queue
 
 The `bulk-issue-queue` tool allows you to push uploaded issues into the

--- a/src/cmd/queue-batches/batch_queue.go
+++ b/src/cmd/queue-batches/batch_queue.go
@@ -73,8 +73,10 @@ func (q *issueQueue) splitQueue(maxPages int) *issueQueue {
 		var l = len(issue.PageLabels)
 		if popped.pages+l <= maxPages {
 			popped.append(issue)
+			logger.Debugf("splitQueue: preparing issue %q: %d pages prepared", issue.Key(), popped.pages)
 		} else {
 			q.append(issue)
+			logger.Debugf("splitQueue: skipping issue %q: too many pages; current pages (%d) + issue (%d) > max (%d)", issue.Key(), popped.pages, l, maxPages)
 		}
 	}
 

--- a/src/cmd/queue-batches/main.go
+++ b/src/cmd/queue-batches/main.go
@@ -51,6 +51,9 @@ func getOpts() *config.Config {
 		conf.MaxBatchSize = opts.MaxBatchSize
 		logger.Infof("Setting MAX_BATCH_SIZE to %d", conf.MaxBatchSize)
 	}
+	if opts.MinBatchSize > opts.MaxBatchSize {
+		logger.Fatalf("Terminating: minimum batch size (%d) is greater than maximum batch size (%d)", conf.MinBatchSize, conf.MaxBatchSize)
+	}
 
 	return conf
 }

--- a/src/cmd/queue-batches/main.go
+++ b/src/cmd/queue-batches/main.go
@@ -12,7 +12,9 @@ import (
 // Command-line options
 type _opts struct {
 	cli.BaseOptions
-	Redo bool `long:"redo" description:"only queue issues needing a re-batch"`
+	Redo         bool `long:"redo" description:"only queue issues needing a re-batch"`
+	MinBatchSize int  `long:"min-batch-size" description:"Don't create a batch with fewer than this many pages (overrides the configuration setting 'MIN_BATCH_SIZE')"`
+	MaxBatchSize int  `long:"max-batch-size" description:"Don't create a batch with more than this many pages (overrides the configuration setting 'MAX_BATCH_SIZE')"`
 }
 
 var opts _opts
@@ -22,7 +24,8 @@ func getOpts() *config.Config {
 	var c = cli.New(&opts)
 	c.AppendUsage("Queues one or more batches depending on the number of " +
 		"issues in the database which are flagged as ready for batching.  See " +
-		"the MAX_BATCH_SIZE and MIN_BATCH_SIZE settings to control how many " +
+		"the MAX_BATCH_SIZE and MIN_BATCH_SIZE settings, or use the " +
+		"--min-batch-size / --max-batch-size flags to control how many " +
 		"pages a batch may contain.")
 	c.AppendUsage(`If --redo is specified, issues must be in a special "ready for ` +
 		`rebatching" state in order to be queued. This is not a state NCA sets ` +
@@ -38,6 +41,15 @@ func getOpts() *config.Config {
 	titles, err = models.Titles()
 	if err != nil {
 		logger.Fatalf("Unable to find titles in the database: %s", err)
+	}
+
+	if opts.MinBatchSize > 0 {
+		conf.MinBatchSize = opts.MinBatchSize
+		logger.Infof("Setting MIN_BATCH_SIZE to %d", conf.MinBatchSize)
+	}
+	if opts.MaxBatchSize > 0 {
+		conf.MaxBatchSize = opts.MaxBatchSize
+		logger.Infof("Setting MAX_BATCH_SIZE to %d", conf.MaxBatchSize)
 	}
 
 	return conf


### PR DESCRIPTION
This feature should get us to a place where we can keep the normal processing of the tool for regular use, while being able to automate when we have a lot of pages sitting waiting for processing. e.g., if we cron the tool to have a minimum of 4400 and a maximum of 4500 pages, it could run daily and kick of batch generations where there are issues that are starting to pile up. This would mean really busy weeks don't require somebody to manually check how many issues are waiting for batching and then running the command-line tool, while still letting normal runs generate smaller batches when it makes sense.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)
