### PR TITLE
Remove unused job type

### DIFF
--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -403,7 +403,6 @@ func runAllQueues(conf *config.Config) {
 				models.JobTypeEmptyBatchFlaggedIssuesList,
 				models.JobTypeIgnoreIssue,
 				models.JobTypeSetBatchStatus,
-				models.JobTypeSetBatchNeedsStagingPurge,
 				models.JobTypeSetBatchLocation,
 				models.JobTypeIssueAction,
 				models.JobTypeBatchAction,

--- a/src/jobs/jobs.go
+++ b/src/jobs/jobs.go
@@ -39,8 +39,6 @@ func DBJobToProcessor(dbJob *models.Job) Processor {
 		return &ArchiveBackups{IssueJob: NewIssueJob(dbJob)}
 	case models.JobTypeSetBatchStatus:
 		return &SetBatchStatus{BatchJob: NewBatchJob(dbJob)}
-	case models.JobTypeSetBatchNeedsStagingPurge:
-		return &SetBatchNeedsStagingPurge{BatchJob: NewBatchJob(dbJob)}
 	case models.JobTypeSetBatchLocation:
 		return &SetBatchLocation{BatchJob: NewBatchJob(dbJob)}
 	case models.JobTypeCreateBatchStructure:

--- a/src/jobs/metadata_jobs.go
+++ b/src/jobs/metadata_jobs.go
@@ -96,23 +96,6 @@ func (j *SetBatchStatus) Process(*config.Config) ProcessResponse {
 	return PRSuccess
 }
 
-// SetBatchNeedsStagingPurge is a wonky one-off to flip the
-// `needs_staging_purge` flag to true for a batch
-type SetBatchNeedsStagingPurge struct {
-	*BatchJob
-}
-
-// Process sets NeedsStagingPurge to true
-func (j *SetBatchNeedsStagingPurge) Process(*config.Config) ProcessResponse {
-	j.DBBatch.NeedStagingPurge = true
-	var err = j.DBBatch.SaveWithoutAction()
-	if err != nil {
-		j.Logger.Errorf("Unable to flag batch %d as needing a staging purge: %s", j.DBBatch.ID, err)
-		return PRFailure
-	}
-	return PRSuccess
-}
-
 // SetBatchLocation is a simple job to update a batch location after files are
 // copied or movied somewhere
 type SetBatchLocation struct {

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -29,7 +29,6 @@ const (
 	JobTypeEmptyBatchFlaggedIssuesList JobType = "empty_batch_flagged_issues_list"
 	JobTypeIgnoreIssue                 JobType = "ignore_issue"
 	JobTypeSetBatchStatus              JobType = "set_batch_status"
-	JobTypeSetBatchNeedsStagingPurge   JobType = "set_batch_needs_staging_purge"
 	JobTypePageSplit                   JobType = "page_split"
 	JobTypeMakeDerivatives             JobType = "make_derivatives"
 	JobTypeMoveDerivatives             JobType = "move_derivatives"
@@ -65,7 +64,6 @@ var ValidJobTypes = []JobType{
 	JobTypeEmptyBatchFlaggedIssuesList,
 	JobTypeIgnoreIssue,
 	JobTypeSetBatchStatus,
-	JobTypeSetBatchNeedsStagingPurge,
 	JobTypePageSplit,
 	JobTypeMakeDerivatives,
 	JobTypeMoveDerivatives,


### PR DESCRIPTION
Removes JobTypeSetBatchNeedsStagingPurge and the corresponding struct used to process these jobs

Not tied to a ticket or anything, just needed to be done and I didn't want to put this in the precompute-sha branch in case that branch keeps dragging on or something.