### PR TITLE
Fix/page counts

### DIFF
--- a/changelogs/2024-08-05-page-count.md
+++ b/changelogs/2024-08-05-page-count.md
@@ -1,3 +1,12 @@
 ### Added
 
 - Various views now include issue and batch page counts
+
+### Migration
+
+- Shut down NCA workers and HTTP daemon. You will have potentially several
+  minutes of downtime.
+- Run database migrations to add the new page count field and then count pages
+  for every issue in the database:
+  - `make && ./bin/migrate-database -c ./settings up`
+- Restart services.

--- a/src/cmd/migrate-database/migrations/20240805110000_count_pages.go
+++ b/src/cmd/migrate-database/migrations/20240805110000_count_pages.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 
 	"github.com/pressly/goose/v3"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
@@ -16,14 +17,26 @@ func init() {
 // load each issue and re-save it so it uses the model's built-in logic to
 // cache page counts
 func upCountIssuePages(_ *sql.Tx) error {
+	slog.Info("Counting all issues' pages")
+	slog.Info("Loading all models. This may take a while...")
 	var issues, err = models.Issues().AllowIgnored().Fetch()
 	if err != nil {
 		return fmt.Errorf("loading all issues: %w", err)
 	}
-	for _, i := range issues {
-		err = i.SaveWithoutAction()
+
+	slog.Info("Load complete.")
+	for i, issue := range issues {
+		var mod = 1000
+		if i < 1000 {
+			mod = 100
+		}
+
+		if i%mod == 0 {
+			slog.Info("Saving models...", "done", i, "remaining", len(issues)-i)
+		}
+		err = issue.SaveWithoutAction()
 		if err != nil {
-			return fmt.Errorf("saving issue %q: %w", i.Key(), err)
+			return fmt.Errorf("saving issue %q: %w", issue.Key(), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Adds logging to the (surprisingly expensive) page count migration, and fixes the changelog to explain that there can be significant downtime.

On a local copy of our database, with not even 100k issues, it can take anywhere from 2 to 5 minutes.