### PR TITLE
Feature/batch from web

### DIFF
--- a/changelogs/2024-08-30-batch-ui.md
+++ b/changelogs/2024-08-30-batch-ui.md
@@ -1,0 +1,22 @@
+### Fixed
+
+
+### Added
+
+- New area in NCA's web UI for generating batches! The command-line tool will
+  continue to exist, but this UI makes it so that people without shell access
+  can easily generate batches on demand.
+
+### Changed
+
+- The nav item "Batches" has been renamed to "Manage Batches" so it's purpose
+  is clearer now that we have a second batch-related nav item.
+
+### Migration
+
+- Shut down NCA workers and HTTP daemon. You will have potentially several
+  minutes of downtime.
+- Run database migrations to add the new page count field and then count pages
+  for every issue in the database:
+  - `make && ./bin/migrate-database -c ./settings up`
+- Restart services.

--- a/hugo/content/workflow/_index.md
+++ b/hugo/content/workflow/_index.md
@@ -66,24 +66,29 @@ generated, the workflow is the same regardless of the source:
 2. An issue reviewer validates the metadata and rejects it or approves it
 3. Once metadata is entered and approved, the issue has its final derivative
    generated (METS XML) and awaits batching
-4. When enough issues are ready, the `queue-batches` CLI will generate batches
-   in the configured `BATCH_OUTPUT_PATH`, and sync to the required files (e.g.,
-   not TIFFs) to production as configured via `BATCH_PRODUCTION_PATH`.
-5. A batch loader must manually load the batches into a staging server and then
+4. When enough issues are ready, there are two ways to generate batches:
+   - A dev can use the `queue-batches` command, generating batches for all
+     issues which are ready.
+   - Somebody with the "batch builder" role can visit NCA's "Create Batches"
+     page and choose which MOCs should have issues batched.
+5. Batches will be put into the configured `BATCH_OUTPUT_PATH`, and required
+   files (e.g., not TIFFs) will be synced to production (as configured via
+   `BATCH_PRODUCTION_PATH`).
+6. A batch loader must manually load the batches into a staging server and then
    flag them as ready for QC
-6. A batch reviewer does quality control on the staging server, verifying the
+7. A batch reviewer does quality control on the staging server, verifying the
    batch's issues look good
    - If all is well, batch reviewer marks the issue as ready for production
    - If not, they reject the batch and can then get individual issues pulled
      out to be re-curated or rejected from NCA entirely. The remaining issues
      are put into a new batch which is then set as being ready for staging
      (repeating step 5).
-7. Batches that are ready for production get loaded to prod by a batch loader.
-8. Batch loader flags the batch as "live", and NCA moves its files to the
+8. Batches that are ready for production get loaded to prod by a batch loader.
+9. Batch loader flags the batch as "live", and NCA moves its files to the
    configured `BATCH_ARCHIVE_PATH`.
-9. Once the batch can be confirmed as fully archived, a batch loader flags it
-   as archived.
-10. Somebody with command-line access to NCA will run `delete-live-done-issues`
+10. Once the batch can be confirmed as fully archived, a batch loader flags it
+    as archived.
+11. Somebody with command-line access to NCA will run `delete-live-done-issues`
     (or set up a cron job) to purge unneeded files from NCA that are part of
     archived batches. It only deletes files when a batch is at least four weeks
     past its archive date to ensure any final problems can be handled.

--- a/hugo/content/workflow/technical.md
+++ b/hugo/content/workflow/technical.md
@@ -109,11 +109,16 @@ An issue XML will be generated (using the METS template defined by the setting
 into the issue location for safe-keeping. Assuming these are done without
 error, the issue is marked "ready for batching".
 
-The batch queue command-line script (compiled to `bin/queue-batches`) grabs all
-issues which are ready to be batched, organizes them by MARC Org Code (a.k.a.,
-awardee) for batching (*each awardee must have its issues in a separate
-batch*), and generates batches if there are enough pages (see the
-`MINIMUM_ISSUE_PAGES` setting).
+A "batch builder" can then select organizations (e.g., the MARC org codes) they
+want batches built for by visiting the "Create Batches" page in NCA. General
+high-level aggregate data should give the batch builder enough information to
+choose what to batch, after which they decide  how big the batches should be.
+
+Alternatively, the batch queue command-line script (compiled to
+`bin/queue-batches`) grabs all issues which are ready to be batched, organizes
+them by organization (a.k.a., MARC Org Code / awardee) for batching (*each
+awardee must have its issues in a separate batch*), and generates batches if
+there are enough pages (see the `MINIMUM_ISSUE_PAGES` setting).
 
 **Note**: the `MINIMUM_ISSUE_PAGES` setting will be ignored if any issues
 waiting to be batched have been ready for batching for more than 30 days. This

--- a/src/cmd/migrate-database/_sql/20240821081100_view_moc_issue_aggregation.sql
+++ b/src/cmd/migrate-database/_sql/20240821081100_view_moc_issue_aggregation.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE VIEW moc_issue_aggregation AS
+  SELECT m.id AS id, m.code, m.name, i.workflow_step, COUNT(i.id) AS issue_count, SUM(i.page_count) AS total_pages
+    FROM mocs m
+    JOIN issues i ON (i.marc_org_code = m.code)
+    GROUP BY marc_org_code, workflow_step
+    ORDER BY marc_org_code, workflow_step;
+
+-- +goose Down
+-- SQL in section 'Down' is executed when this migration is rolled back
+DROP VIEW moc_issue_aggregation;

--- a/src/cmd/migrate-database/_sql/20240821081100_view_moc_issue_aggregation.sql
+++ b/src/cmd/migrate-database/_sql/20240821081100_view_moc_issue_aggregation.sql
@@ -4,6 +4,7 @@ CREATE VIEW moc_issue_aggregation AS
   SELECT m.id AS id, m.code, m.name, i.workflow_step, COUNT(i.id) AS issue_count, SUM(i.page_count) AS total_pages
     FROM mocs m
     JOIN issues i ON (i.marc_org_code = m.code)
+    WHERE i.ignored = 0
     GROUP BY marc_org_code, workflow_step
     ORDER BY marc_org_code, workflow_step;
 

--- a/src/cmd/queue-batches/batch_queue.go
+++ b/src/cmd/queue-batches/batch_queue.go
@@ -44,7 +44,7 @@ func (q *batchQueue) FindReadyIssues(redo bool) {
 		var moc = i.MARCOrgCode
 		var mocQ, ok = q.mocQueue[moc]
 		if !ok {
-			mocQ = issuequeue.New(titles)
+			mocQ = issuequeue.New()
 			q.mocQueue[moc] = mocQ
 			q.mocList = append(q.mocList, moc)
 		}

--- a/src/cmd/queue-batches/batch_queue.go
+++ b/src/cmd/queue-batches/batch_queue.go
@@ -65,12 +65,12 @@ func (q *batchQueue) CreateBatches(seed string) []*models.Batch {
 	// Step 1: clean up queues
 	var queues []*issuequeue.Queue
 	for moc, mocQueue := range q.mocQueue {
-		var newQ = mocQueue.RemoveIf(func(i *issuequeue.Issue) bool {
+		var newQ = mocQueue.Filter(func(i *issuequeue.Issue) bool {
 			if i.Embargoed {
 				logger.Debugf("Removing issue %q from %s queue: embargoed", i.Key(), moc)
-				return true
+				return false
 			}
-			return false
+			return true
 		})
 
 		// This can happen if all issues are embargoed

--- a/src/cmd/queue-batches/main.go
+++ b/src/cmd/queue-batches/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/jobs"
-	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 )
 
 // Command-line options
@@ -18,7 +17,6 @@ type _opts struct {
 }
 
 var opts _opts
-var titles models.TitleList
 
 func getOpts() *config.Config {
 	var c = cli.New(&opts)
@@ -36,11 +34,6 @@ func getOpts() *config.Config {
 	var err = dbi.DBConnect(conf.DatabaseConnect)
 	if err != nil {
 		logger.Fatalf("Error trying to connect to database: %s", err)
-	}
-
-	titles, err = models.Titles()
-	if err != nil {
-		logger.Fatalf("Unable to find titles in the database: %s", err)
 	}
 
 	if opts.MinBatchSize > 0 {

--- a/src/cmd/server/internal/batchmakerhandler/handlers.go
+++ b/src/cmd/server/internal/batchmakerhandler/handlers.go
@@ -46,10 +46,16 @@ func buildBatchForm(w http.ResponseWriter, req *http.Request) {
 	var aggs, err = models.MOCIssueAggregations()
 	if err != nil {
 		logger.Errorf("Unable to load MOC issue aggregation: %s", err)
-		r.Error(http.StatusInternalServerError, "Error trying to pull MOC list - try again or contact support")
+		r.Error(http.StatusInternalServerError, "Error trying to prepare lists - try again or contact support")
 		return
 	}
 
-	r.Vars.Data["MOCIssueAggregations"] = getAggregations(aggs)
+	r.Vars.Data["MOCIssueAggregations"], err = getAggregations(aggs)
+	if err != nil {
+		logger.Errorf("Unable to transform MOC aggregation data: %s", err)
+		r.Error(http.StatusInternalServerError, "Error trying to prepare lists - try again or contact support")
+		return
+	}
+
 	r.Render(buildBatchFormTmpl)
 }

--- a/src/cmd/server/internal/batchmakerhandler/handlers.go
+++ b/src/cmd/server/internal/batchmakerhandler/handlers.go
@@ -1,0 +1,44 @@
+package batchmakerhandler
+
+import (
+	"net/http"
+	"path"
+
+	"github.com/gorilla/mux"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/responder"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/web/tmpl"
+)
+
+var (
+	basePath string
+
+	// layout is the base template, cloned from the responder's layout, from
+	// which all subpages are built
+	layout *tmpl.TRoot
+
+	// buildBatchFormTmpl is the form for finding issues to put into one or more batches
+	buildBatchFormTmpl *tmpl.Template
+)
+
+// Setup sets up all the routing rules and other configuration
+func Setup(r *mux.Router, baseWebPath string) {
+	basePath = baseWebPath
+	var s = r.PathPrefix(basePath).Subrouter()
+	s.Path("").Handler(canBuild(buildBatchForm))
+
+	layout = responder.Layout.Clone()
+	layout.Funcs(tmpl.FuncMap{
+		"BatchMakerHomeURL":   func() string { return basePath },
+		"BatchMakerFilterURL": func() string { return path.Join(basePath, "filter") },
+	})
+	layout.Path = path.Join(layout.Path, "batchmaker")
+
+	buildBatchFormTmpl = layout.MustBuild("build.go.html")
+}
+
+// buildBatchForm shows a form for filtering issues that are ready for batching
+func buildBatchForm(w http.ResponseWriter, req *http.Request) {
+	var r = responder.Response(w, req)
+	r.Vars.Title = "Filter Issues For Batching"
+	r.Render(buildBatchFormTmpl)
+}

--- a/src/cmd/server/internal/batchmakerhandler/handlers.go
+++ b/src/cmd/server/internal/batchmakerhandler/handlers.go
@@ -1,8 +1,11 @@
 package batchmakerhandler
 
 import (
+	"fmt"
+	"html/template"
 	"net/http"
 	"path"
+	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/responder"
@@ -20,6 +23,15 @@ var (
 
 	// buildBatchFormTmpl is the form for finding issues to put into one or more batches
 	buildBatchFormTmpl *tmpl.Template
+
+	// showBatchIssuesFormTmpl shows the number of issues which will be put into
+	// a batch and lets the user decide whether or not to proceed as well as
+	// selecting the maximum batch size
+	showBatchIssuesFormTmpl *tmpl.Template
+
+	// showGenerateFormTmpl shows a form to preview what batches will be
+	// generated and give the user a final chance to say "oops, no thanks"
+	showGenerateFormTmpl *tmpl.Template
 )
 
 // Setup sets up all the routing rules and other configuration
@@ -27,15 +39,77 @@ func Setup(r *mux.Router, baseWebPath string) {
 	basePath = baseWebPath
 	var s = r.PathPrefix(basePath).Subrouter()
 	s.Path("").Handler(canBuild(buildBatchForm))
+	s.Path("/filter").Handler(canBuild(showBatchIssuesForm))
+	s.Path("/generate").Handler(canBuild(showGenerateForm))
 
 	layout = responder.Layout.Clone()
 	layout.Funcs(tmpl.FuncMap{
-		"BatchMakerHomeURL":   func() string { return basePath },
-		"BatchMakerFilterURL": func() string { return path.Join(basePath, "filter") },
+		"BatchMakerHomeURL":     func() string { return basePath },
+		"BatchMakerFilterURL":   func() string { return path.Join(basePath, "filter") },
+		"BatchMakerGenerateURL": func() string { return path.Join(basePath, "generate") },
 	})
 	layout.Path = path.Join(layout.Path, "batchmaker")
 
 	buildBatchFormTmpl = layout.MustBuild("build.go.html")
+	showBatchIssuesFormTmpl = layout.MustBuild("show-issues.go.html")
+	showGenerateFormTmpl = layout.MustBuild("generate-form.go.html")
+}
+
+// filteredAggs returns a list of aggregations filtered by the form-submitted
+// MOC ids, ready for use in handlers
+func filteredAggs(req *http.Request) ([]*aggregation, error) {
+	var err = req.ParseForm()
+	if err != nil {
+		return nil, fmt.Errorf("parsing form data: %w", err)
+	}
+
+	var list = req.Form["moc"]
+
+	// If we got here with nothing selected, no sense hitting the potentially
+	// expensive database view
+	if len(list) == 0 {
+		return nil, nil
+	}
+
+	var allAggs []*models.IssueAggregation
+	allAggs, err = models.MOCIssueAggregations()
+	if err != nil {
+		return nil, fmt.Errorf("reading DB aggregations: %w", err)
+	}
+
+	var aggs []*models.IssueAggregation
+	for _, val := range list {
+		for _, agg := range allAggs {
+			var id, _ = strconv.ParseInt(val, 10, 64)
+			if agg.MOC.ID == id {
+				aggs = append(aggs, agg)
+			}
+		}
+	}
+
+	return getAggregations(aggs)
+}
+
+// readAggs gets the responder, uses filteredAggs() to get the list of aggs,
+// and automatically processes common errors or redirects needed for a handler.
+// If exit is true, the caller should not process the request further.
+func readAggs(w http.ResponseWriter, req *http.Request) (r *responder.Responder, aggs []*aggregation, exit bool) {
+	var err error
+
+	r = responder.Response(w, req)
+	aggs, err = filteredAggs(req)
+	if err != nil {
+		logger.Errorf("Unable to get filtered aggregations list: %s", err)
+		r.Error(http.StatusInternalServerError, "Error processing request - try again or contact support")
+		return r, aggs, true
+	}
+	if len(aggs) == 0 {
+		http.SetCookie(w, &http.Cookie{Name: "Alert", Value: "No selections made: nothing to batch", Path: "/"})
+		http.Redirect(w, req, basePath, http.StatusFound)
+		return r, aggs, true
+	}
+
+	return r, aggs, false
 }
 
 // buildBatchForm shows a form for filtering issues that are ready for batching
@@ -58,4 +132,63 @@ func buildBatchForm(w http.ResponseWriter, req *http.Request) {
 	}
 
 	r.Render(buildBatchFormTmpl)
+}
+
+func renderBatchIssuesForm(r *responder.Responder, aggs []*aggregation) {
+	r.Vars.Title = "Select Batch Parameters"
+	r.Vars.Data["MaxPages"], _ = strconv.Atoi(r.Request.FormValue("maxpages"))
+	r.Vars.Data["MOCIssueAggregations"] = aggs
+	r.Render(showBatchIssuesFormTmpl)
+}
+
+// showBatchIssuesForm grabs issues for the selected MOCs and displays options
+// for creating a batch
+func showBatchIssuesForm(w http.ResponseWriter, req *http.Request) {
+	var r, aggs, exit = readAggs(w, req)
+	if exit {
+		return
+	}
+
+	renderBatchIssuesForm(r, aggs)
+}
+
+func showGenerateForm(w http.ResponseWriter, req *http.Request) {
+	var r, aggs, exit = readAggs(w, req)
+	if exit {
+		return
+	}
+
+	var max, _ = strconv.Atoi(req.FormValue("maxpages"))
+	if max < 1 {
+		r.Vars.Alert = template.HTML("Maximum size is invalid. Please enter a positive number.")
+		renderBatchIssuesForm(r, aggs)
+		return
+	}
+
+	// Build the (potentially final) batch queues, wrapping them to give the user
+	// more context
+	var queues []*Q
+	for _, agg := range aggs {
+		var readyQ = agg.ReadyForBatching
+		var splitQs = readyQ.Split(max)
+		var i int
+		for _, sq := range splitQs {
+			i++
+			queues = append(queues, &Q{
+				Sequence: i,
+				MOC:      agg.MOC,
+				Queue:    sq,
+			})
+		}
+	}
+	if len(queues) > 1 {
+		r.Vars.Title = "Generate Batches?"
+	} else {
+		r.Vars.Title = "Generate Batch?"
+	}
+	r.Vars.Data["Queues"] = queues
+	r.Vars.Data["MaxPages"] = max
+	r.Vars.Data["MOCIssueAggregations"] = aggs
+
+	r.Render(showGenerateFormTmpl)
 }

--- a/src/cmd/server/internal/batchmakerhandler/handlers.go
+++ b/src/cmd/server/internal/batchmakerhandler/handlers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/responder"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
-	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/web/tmpl"
 )
 
@@ -51,12 +50,6 @@ func buildBatchForm(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Remove information that won't help anybody make decisions (e.g., InProduction)
-	for _, agg := range aggs {
-		delete(agg.Counts, schema.WSNil)
-		delete(agg.Counts, schema.WSInProduction)
-	}
-
-	r.Vars.Data["MOCIssueAggregations"] = aggs
+	r.Vars.Data["MOCIssueAggregations"] = getAggregations(aggs)
 	r.Render(buildBatchFormTmpl)
 }

--- a/src/cmd/server/internal/batchmakerhandler/middleware.go
+++ b/src/cmd/server/internal/batchmakerhandler/middleware.go
@@ -1,0 +1,13 @@
+package batchmakerhandler
+
+import (
+	"net/http"
+
+	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/responder"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/privilege"
+)
+
+// canBuild verifies the user can build a batch
+func canBuild(h http.HandlerFunc) http.Handler {
+	return responder.MustHavePrivilege(privilege.GenerateBatches, h)
+}

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -63,8 +63,9 @@ func getAggregations(aggs []*models.IssueAggregation) ([]*aggregation, error) {
 		}
 		var embargoed = func(issue *issuequeue.Issue) bool { return issue.Embargoed }
 		var notEmbargoed = func(issue *issuequeue.Issue) bool { return !issue.Embargoed }
-		var embargoedQ = tempQ.RemoveIf(embargoed)
-		a.ReadyForBatching = tempQ.RemoveIf(notEmbargoed)
+		var embargoedQ = tempQ.RemoveIf(notEmbargoed)
+		a.ReadyForBatching = tempQ.RemoveIf(embargoed)
+
 		a.Counts = append(
 			a.Counts,
 			count{Title: "Ready for batching", Issues: a.ReadyForBatching.Len(), Pages: a.ReadyForBatching.Pages},

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -63,8 +63,8 @@ func getAggregations(aggs []*models.IssueAggregation) ([]*aggregation, error) {
 		}
 		var embargoed = func(issue *issuequeue.Issue) bool { return issue.Embargoed }
 		var notEmbargoed = func(issue *issuequeue.Issue) bool { return !issue.Embargoed }
-		var embargoedQ = tempQ.RemoveIf(notEmbargoed)
-		a.ReadyForBatching = tempQ.RemoveIf(embargoed)
+		var embargoedQ = tempQ.Filter(embargoed)
+		a.ReadyForBatching = tempQ.Filter(notEmbargoed)
 
 		// This is theoretically possible if all "ready" issues are in fact still
 		// under embargo. The information may still be worth displaying, but it

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -91,3 +91,12 @@ func getAggregations(aggs []*models.IssueAggregation) ([]*aggregation, error) {
 
 	return list, nil
 }
+
+// Q wraps issuequeue.Queue to add some context for the template to display. Q
+// is not, however, likely to be found anywhere near farpoint. At least not in
+// the NCA continuum.
+type Q struct {
+	Sequence int
+	MOC      *models.MOC
+	Queue    *issuequeue.Queue
+}

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -3,6 +3,7 @@ package batchmakerhandler
 import (
 	"fmt"
 
+	"github.com/uoregon-libraries/newspaper-curation-app/src/duration"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/issuequeue"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
@@ -22,6 +23,7 @@ type aggregation struct {
 	MOC              *models.MOC
 	Counts           []count
 	ReadyForBatching *issuequeue.Queue
+	Age              string
 }
 
 func (a *aggregation) appendCount(agg *models.IssueAggregation, title string, steps ...schema.WorkflowStep) {
@@ -73,6 +75,14 @@ func getAggregations(aggs []*models.IssueAggregation) ([]*aggregation, error) {
 		if a.ReadyForBatching.Len() == 0 {
 			continue
 		}
+
+		var d = duration.FromDays(int(a.ReadyForBatching.DaysStale))
+		if d.Zero() {
+			a.Age = "Less than a day"
+		} else {
+			a.Age = d.String()
+		}
+
 		if embargoedQ.Len() > 0 {
 			a.Counts = append(
 				a.Counts,

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -73,10 +73,6 @@ func getAggregations(aggs []*models.IssueAggregation) ([]*aggregation, error) {
 		if a.ReadyForBatching.Len() == 0 {
 			continue
 		}
-		a.Counts = append(
-			a.Counts,
-			count{Title: "Ready for batching", Issues: a.ReadyForBatching.Len(), Pages: a.ReadyForBatching.Pages},
-		)
 		if embargoedQ.Len() > 0 {
 			a.Counts = append(
 				a.Counts,

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -1,0 +1,58 @@
+package batchmakerhandler
+
+import (
+	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
+)
+
+type count struct {
+	Title  string
+	Issues int64
+	Pages  int64
+}
+
+// aggregation is our batch-generation-view version of the MOC issue aggregation data
+type aggregation struct {
+	MOC    *models.MOC
+	Counts []count
+}
+
+func (a *aggregation) appendCount(agg *models.IssueAggregation, title string, steps ...schema.WorkflowStep) {
+	var issues, pages int64
+	for _, step := range steps {
+		issues += agg.Counts[step].IssueCount
+		pages += agg.Counts[step].TotalPages
+	}
+
+	if issues > 0 {
+		a.Counts = append(a.Counts, count{Title: title, Issues: issues, Pages: pages})
+	}
+}
+
+// getAggregations builds our template-friendly structures, transforming
+// the data so it helps people decide what to batch
+func getAggregations(aggs []*models.IssueAggregation) []*aggregation {
+	var list []*aggregation
+	for _, agg := range aggs {
+		if agg.Counts[schema.WSReadyForBatching].IssueCount == 0 {
+			continue
+		}
+
+		var a = &aggregation{MOC: agg.MOC}
+
+		// Add counts for useful data points, merging similar ones to reduce noise.
+		//
+		// NOTE: order matters here! We want users to see the "Ready for batching"
+		// numbers first, and then prioritize items that are "further back" in the
+		// process.
+		a.appendCount(agg, "Ready for batching", schema.WSReadyForBatching)
+		a.appendCount(agg, "Uploaded, not in NCA", schema.WSSFTP, schema.WSScan)
+		a.appendCount(agg, "Waiting on user action", schema.WSAwaitingPageReview, schema.WSReadyForMetadataEntry, schema.WSAwaitingMetadataReview)
+		a.appendCount(agg, "In NCA, processing", schema.WSAwaitingProcessing, schema.WSReadyForMETSXML)
+		a.appendCount(agg, "In NCA, flagged (unfixable errors)", schema.WSUnfixableMetadataError)
+
+		list = append(list, a)
+	}
+
+	return list
+}

--- a/src/cmd/server/internal/batchmakerhandler/schema.go
+++ b/src/cmd/server/internal/batchmakerhandler/schema.go
@@ -1,27 +1,34 @@
 package batchmakerhandler
 
 import (
+	"fmt"
+
+	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/issuequeue"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
 )
 
 type count struct {
 	Title  string
-	Issues int64
-	Pages  int64
+	Issues int
+	Pages  int
 }
 
-// aggregation is our batch-generation-view version of the MOC issue aggregation data
+// aggregation is our batch-generation-view of MOC issue aggregation data - we
+// get transform the raw for easy display, but also pull the full list of
+// "ready for batching" issues in order to show detailed information about
+// embargoes, how long the longest issues have been waiting, etc.
 type aggregation struct {
-	MOC    *models.MOC
-	Counts []count
+	MOC              *models.MOC
+	Counts           []count
+	ReadyForBatching *issuequeue.Queue
 }
 
 func (a *aggregation) appendCount(agg *models.IssueAggregation, title string, steps ...schema.WorkflowStep) {
-	var issues, pages int64
+	var issues, pages int
 	for _, step := range steps {
-		issues += agg.Counts[step].IssueCount
-		pages += agg.Counts[step].TotalPages
+		issues += int(agg.Counts[step].IssueCount)
+		pages += int(agg.Counts[step].TotalPages)
 	}
 
 	if issues > 0 {
@@ -29,23 +36,45 @@ func (a *aggregation) appendCount(agg *models.IssueAggregation, title string, st
 	}
 }
 
-// getAggregations builds our template-friendly structures, transforming
-// the data so it helps people decide what to batch
-func getAggregations(aggs []*models.IssueAggregation) []*aggregation {
+// getAggregations builds our template-friendly structures, transforming the
+// data so it helps people decide what to batch, and removing data that would
+// just be noise, such as MOCs which have no issues ready for batching.
+func getAggregations(aggs []*models.IssueAggregation) ([]*aggregation, error) {
 	var list []*aggregation
 	for _, agg := range aggs {
 		if agg.Counts[schema.WSReadyForBatching].IssueCount == 0 {
 			continue
 		}
 
+		// Get "ready for batching" issues fully loaded so we can provide embargo /
+		// stale details before other counts
 		var a = &aggregation{MOC: agg.MOC}
+		var issues, err = models.Issues().MOC(a.MOC.Code).InWorkflowStep(schema.WSReadyForBatching).BatchID(0).Fetch()
+		if err != nil {
+			return nil, fmt.Errorf("fetching issues for %q: %w", a.MOC.Code, err)
+		}
 
-		// Add counts for useful data points, merging similar ones to reduce noise.
-		//
-		// NOTE: order matters here! We want users to see the "Ready for batching"
-		// numbers first, and then prioritize items that are "further back" in the
-		// process.
-		a.appendCount(agg, "Ready for batching", schema.WSReadyForBatching)
+		var tempQ = issuequeue.New()
+		for _, issue := range issues {
+			err = tempQ.Append(issue)
+			if err != nil {
+				return nil, fmt.Errorf("appending issue %q to aggregation queue %q: %w", issue.Key(), a.MOC.Code, err)
+			}
+		}
+		var embargoed = func(issue *issuequeue.Issue) bool { return issue.Embargoed }
+		var notEmbargoed = func(issue *issuequeue.Issue) bool { return !issue.Embargoed }
+		var embargoedQ = tempQ.RemoveIf(embargoed)
+		a.ReadyForBatching = tempQ.RemoveIf(notEmbargoed)
+		a.Counts = append(
+			a.Counts,
+			count{Title: "Ready for batching", Issues: a.ReadyForBatching.Len(), Pages: a.ReadyForBatching.Pages},
+		)
+		a.Counts = append(
+			a.Counts,
+			count{Title: "Ready, but under embargo", Issues: embargoedQ.Len(), Pages: embargoedQ.Pages},
+		)
+
+		// Add counts for other useful data points, merging similar ones to reduce noise
 		a.appendCount(agg, "Uploaded, not in NCA", schema.WSSFTP, schema.WSScan)
 		a.appendCount(agg, "Waiting on user action", schema.WSAwaitingPageReview, schema.WSReadyForMetadataEntry, schema.WSAwaitingMetadataReview)
 		a.appendCount(agg, "In NCA, processing", schema.WSAwaitingProcessing, schema.WSReadyForMETSXML)
@@ -54,5 +83,5 @@ func getAggregations(aggs []*models.IssueAggregation) []*aggregation {
 		list = append(list, a)
 	}
 
-	return list
+	return list, nil
 }

--- a/src/cmd/server/internal/responder/templates.go
+++ b/src/cmd/server/internal/responder/templates.go
@@ -137,6 +137,7 @@ func InitRootTemplate(templatePath string) {
 		"ViewUploadedIssues":    func() *privilege.Privilege { return privilege.ViewUploadedIssues },
 		"ModifyUploadedIssues":  func() *privilege.Privilege { return privilege.ModifyUploadedIssues },
 		"SearchIssues":          func() *privilege.Privilege { return privilege.SearchIssues },
+		"GenerateBatches":       func() *privilege.Privilege { return privilege.GenerateBatches },
 		"ViewBatchStatus":       func() *privilege.Privilege { return privilege.ViewBatchStatus },
 		"ViewQCReadyBatches":    func() *privilege.Privilege { return privilege.ViewQCReadyBatches },
 		"ApproveQCReadyBatches": func() *privilege.Privilege { return privilege.ApproveQCReadyBatches },

--- a/src/cmd/server/internal/responder/templates.go
+++ b/src/cmd/server/internal/responder/templates.go
@@ -79,7 +79,7 @@ func actionVerb(at string) string {
 	return models.ActionType(at).Describe()
 }
 
-func pluralize(singular, plural string, count int64) string {
+func pluralize(singular, plural string, count int) string {
 	if count == 1 {
 		return fmt.Sprintf("%d %s", count, singular)
 	}

--- a/src/cmd/server/internal/responder/templates.go
+++ b/src/cmd/server/internal/responder/templates.go
@@ -79,7 +79,7 @@ func actionVerb(at string) string {
 	return models.ActionType(at).Describe()
 }
 
-func pluralize(singular, plural string, count int) string {
+func pluralize(singular, plural string, count int64) string {
 	if count == 1 {
 		return fmt.Sprintf("%d %s", count, singular)
 	}

--- a/src/cmd/server/main.go
+++ b/src/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/audithandler"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/batchhandler"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/batchmakerhandler"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/issuefinderhandler"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/mochandler"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cmd/server/internal/responder"
@@ -128,6 +129,7 @@ func startServer() {
 	userhandler.Setup(r, path.Join(hp, "users"))
 	titlehandler.Setup(r, path.Join(hp, "titles"), conf)
 	audithandler.Setup(r, path.Join(hp, "logs"))
+	batchmakerhandler.Setup(r, path.Join(hp, "batchmaker"))
 
 	r.NewRoute().Path(hp).HandlerFunc(home)
 

--- a/src/cmd/server/main.go
+++ b/src/cmd/server/main.go
@@ -129,7 +129,7 @@ func startServer() {
 	userhandler.Setup(r, path.Join(hp, "users"))
 	titlehandler.Setup(r, path.Join(hp, "titles"), conf)
 	audithandler.Setup(r, path.Join(hp, "logs"))
-	batchmakerhandler.Setup(r, path.Join(hp, "batchmaker"))
+	batchmakerhandler.Setup(r, path.Join(hp, "batchmaker"), conf)
 
 	r.NewRoute().Path(hp).HandlerFunc(home)
 

--- a/src/duration/duration.go
+++ b/src/duration/duration.go
@@ -120,6 +120,51 @@ func appendDuration(out []string, num int, unit string) []string {
 	return append(out, strconv.Itoa(num)+" "+unit+"s")
 }
 
+const daysPerYear = 365.2425
+const daysPerMonth = daysPerYear / 12
+
+// FromDays lets us pass in a number of days, and "reduces" the value to a
+// meaningful duration by extracting a rough estimate of years and months. The
+// corresponding duration *will not* be 100% accurate! There are not a set
+// number of days in a month, or even in a year. The Duration will be close,
+// but cannot be used if precision is necessary.
+func FromDays(days int) Duration {
+	var d Duration
+
+	// If we have several years' worth of days, we sort of fake leap years.
+	if days >= 1460 {
+		d.Years += int(float64(days) / daysPerYear)
+		days -= int(float64(d.Years) * daysPerYear)
+	}
+
+	// Otherwise, just a simple 365 division
+	if days >= 365 {
+		d.Years += days / 365
+		days %= 365
+	}
+
+	// If we have a lot of days left, we calculate months sort of accurately
+	if days >= 183 {
+		d.Months += int(float64(days) / daysPerMonth)
+		days -= int(float64(d.Months) * daysPerMonth)
+	}
+
+	// Otherwise, just 30
+	if days >= 30 {
+		d.Months += days / 30
+		days %= 30
+	}
+
+	if days >= 7 {
+		d.Weeks += days / 7
+		days %= 7
+	}
+
+	d.Days = days
+
+	return d
+}
+
 func (d Duration) String() string {
 	var out []string
 	out = appendDuration(out, d.Years, "year")

--- a/src/duration/duration_test.go
+++ b/src/duration/duration_test.go
@@ -42,6 +42,32 @@ func TestParseWeird(t *testing.T) {
 	}
 }
 
+func TestFromDays(t *testing.T) {
+	var tests = map[string]struct {
+		days     int
+		expected string
+	}{
+		"Zero":        {days: 0, expected: "0 days"},
+		"Simple":      {days: 5, expected: "5 days"},
+		"Weeks":       {days: 12, expected: "1 week 5 days"},
+		"WeeksNoDays": {days: 21, expected: "3 weeks"},
+		"Months":      {days: 75, expected: "2 months 2 weeks 1 day"},
+		"ManyMonths":  {days: 361, expected: "11 months 3 weeks 6 days"},
+		"Years":       {days: 365*2 + 15, expected: "2 years 2 weeks 1 day"},
+		"ManyYears":   {days: 365 * 10, expected: "9 years 11 months 4 weeks 1 day"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var dur = FromDays(tc.days)
+			var got = dur.String()
+			if got != tc.expected {
+				t.Errorf("%d days should have returned %q, but we got %q", tc.days, tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestString(t *testing.T) {
 	var d, err = Parse("1 month 3 years 2 weeks 4 days")
 	if err != nil {

--- a/src/internal/issuequeue/issue.go
+++ b/src/internal/issuequeue/issue.go
@@ -15,6 +15,10 @@ type Issue struct {
 }
 
 func wrapIssue(dbIssue *models.Issue) (*Issue, error) {
+	if dbIssue.Title == nil {
+		return nil, fmt.Errorf("wrapping issue: invalid: no associated title")
+	}
+
 	var issueDate, err = time.Parse("2006-01-02", dbIssue.Date)
 	if err != nil {
 		return nil, fmt.Errorf("invalid date %q: %w", dbIssue.Date, err)

--- a/src/internal/issuequeue/issue.go
+++ b/src/internal/issuequeue/issue.go
@@ -14,18 +14,13 @@ type Issue struct {
 	Embargoed bool
 }
 
-func wrapIssue(titles models.TitleList, dbIssue *models.Issue) (*Issue, error) {
+func wrapIssue(dbIssue *models.Issue) (*Issue, error) {
 	var issueDate, err = time.Parse("2006-01-02", dbIssue.Date)
 	if err != nil {
 		return nil, fmt.Errorf("invalid date %q: %w", dbIssue.Date, err)
 	}
 
 	var i = &Issue{Issue: dbIssue}
-
-	i.Title = titles.Find(i.LCCN)
-	if i.Title == nil {
-		return nil, fmt.Errorf("unknown LCCN %q", i.LCCN)
-	}
 
 	var embargoLiftDate time.Time
 	embargoLiftDate, err = i.Title.CalculateEmbargoLiftDate(issueDate)

--- a/src/internal/issuequeue/issue_test.go
+++ b/src/internal/issuequeue/issue_test.go
@@ -27,13 +27,18 @@ var testTitleList = models.TitleList{
 }
 
 func makeIssue(lccn, date string) *models.Issue {
-	var dbi = models.NewIssue("oru", lccn, date, 1)
-	dbi.MetadataApprovedAt = now
-	return dbi
+	return &models.Issue{
+		MARCOrgCode:        "oru",
+		LCCN:               lccn,
+		Date:               date,
+		Edition:            1,
+		Title:              testTitleList.FindByLCCN(lccn),
+		MetadataApprovedAt: now,
+	}
 }
 
 func mustWrap(dbi *models.Issue, t *testing.T) *Issue {
-	var i, err = wrapIssue(testTitleList, dbi)
+	var i, err = wrapIssue(dbi)
 	if err != nil {
 		t.Errorf("Error wrapping issue: %s", err)
 	}
@@ -86,7 +91,7 @@ func TestWrapIssueTableDriven(t *testing.T) {
 				dbi.MetadataApprovedAt = tc.metadataApprovedAt
 			}
 
-			var i, err = wrapIssue(testTitleList, dbi)
+			var i, err = wrapIssue(dbi)
 			if tc.expectError && err == nil {
 				t.Errorf("Expected an error but didn't get one")
 			} else if !tc.expectError && err != nil {

--- a/src/internal/issuequeue/queue.go
+++ b/src/internal/issuequeue/queue.go
@@ -111,3 +111,8 @@ func (q *Queue) DBIssues() []*models.Issue {
 	}
 	return dbIssues
 }
+
+// Len returns the number of elements in the queue
+func (q *Queue) Len() int {
+	return len(q.list)
+}

--- a/src/internal/issuequeue/queue.go
+++ b/src/internal/issuequeue/queue.go
@@ -13,22 +13,21 @@ import (
 type Queue struct {
 	list      []*Issue
 	seen      map[string]bool
-	titles    models.TitleList
 	Pages     int
 	DaysStale float64
 }
 
 // New returns an issue Queue which will use the given title list to look up
 // data for embargo/staleness data
-func New(titles models.TitleList) *Queue {
-	return &Queue{seen: make(map[string]bool), titles: titles}
+func New() *Queue {
+	return &Queue{seen: make(map[string]bool)}
 }
 
 // Append adds the given issue to the queue, first computing its embarge and
 // stale date. If dates are bad, a title isn't found, or other metadata errors
 // prevent these computations, an error is returned.
 func (q *Queue) Append(issue *models.Issue) error {
-	var i, err = wrapIssue(q.titles, issue)
+	var i, err = wrapIssue(issue)
 	if err != nil {
 		return fmt.Errorf("wrapping issue: %w", err)
 	}
@@ -40,7 +39,7 @@ func (q *Queue) Append(issue *models.Issue) error {
 // RemoveIf returns a copy of q without any issues which return true in the
 // remove function
 func (q *Queue) RemoveIf(remove func(*Issue) bool) *Queue {
-	var newQ = New(q.titles)
+	var newQ = New()
 	for _, i := range q.list {
 		if !remove(i) {
 			newQ.appendWrapped(i)
@@ -79,7 +78,7 @@ func (q *Queue) Split(maxPages int) []*Queue {
 	var numQueues = int(math.Ceil(float64(q.Pages) / float64(maxPages)))
 	var queues = make([]*Queue, numQueues)
 	for i := range queues {
-		queues[i] = New(q.titles)
+		queues[i] = New()
 	}
 
 	// Find the smallest queue to add the next issue

--- a/src/internal/issuequeue/queue.go
+++ b/src/internal/issuequeue/queue.go
@@ -36,12 +36,12 @@ func (q *Queue) Append(issue *models.Issue) error {
 	return nil
 }
 
-// RemoveIf returns a copy of q without any issues which return true in the
-// remove function
-func (q *Queue) RemoveIf(remove func(*Issue) bool) *Queue {
+// Filter returns a new Queue that includes only the elements for which filter
+// returns true
+func (q *Queue) Filter(filter func(*Issue) bool) *Queue {
 	var newQ = New()
 	for _, i := range q.list {
-		if !remove(i) {
+		if filter(i) {
 			newQ.appendWrapped(i)
 		}
 	}

--- a/src/internal/issuequeue/queue_test.go
+++ b/src/internal/issuequeue/queue_test.go
@@ -15,13 +15,19 @@ func atoi(s string) int {
 	return i
 }
 
-// mkissue converts a string to issue data for easier testing. The string is a
-// slash-delimited set of values: parseable date, edition number, and page
+// strToIssue converts a string to issue data for easier testing. The string is
+// a slash-delimited set of values: parseable date, edition number, and page
 // count. All issues use the "good" LCCN, so tests using this shouldn't be
 // testing anything related to wrapping potentially bad issues.
-func mkissue(s string) *models.Issue {
+func strToIssue(s string) *models.Issue {
 	var parts = strings.Split(s, "/")
-	return &models.Issue{LCCN: lccnSimple, Date: parts[0], Edition: atoi(parts[1]), PageCount: atoi(parts[2])}
+	return &models.Issue{
+		LCCN:      lccnSimple,
+		Date:      parts[0],
+		Edition:   atoi(parts[1]),
+		PageCount: atoi(parts[2]),
+		Title:     testTitleList.FindByLCCN(lccnSimple),
+	}
 }
 
 func TestAppend(t *testing.T) {
@@ -53,10 +59,10 @@ func TestAppend(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var q = New(testTitleList)
+			var q = New()
 			var hadError error
 			for _, i := range tc.issues {
-				var err = q.Append(mkissue(i))
+				var err = q.Append(strToIssue(i))
 				if err != nil {
 					t.Logf("%q error: %s", i, err)
 					hadError = err
@@ -110,9 +116,9 @@ func TestSplit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var q = New(testTitleList)
+			var q = New()
 			for i, pages := range tc.issuePages {
-				q.Append(mkissue(fmt.Sprintf("2024-01-02/%02d/%d", i, pages)))
+				q.Append(strToIssue(fmt.Sprintf("2024-01-02/%02d/%d", i, pages)))
 			}
 
 			var qlist = q.Split(tc.queuePages)

--- a/src/internal/issuequeue/queue_test.go
+++ b/src/internal/issuequeue/queue_test.go
@@ -76,9 +76,9 @@ func TestAppend(t *testing.T) {
 				t.Fatalf("Expected no errors, got: %s", hadError)
 			}
 
-			var got = len(q.list)
+			var got = q.Len()
 			if got != tc.expectedCount {
-				t.Fatalf("Expected %d issue(s), got %d", tc.expectedCount, got)
+				t.Fatalf("Expected IssueCount to be %d, got %d", tc.expectedCount, got)
 			}
 			got = q.Pages
 			if got != tc.expectedPages {

--- a/src/models/issue.go
+++ b/src/models/issue.go
@@ -145,9 +145,19 @@ func FindFlaggedIssue(batchID, issueID int64) (*FlaggedIssue, error) {
 	return list[0], err
 }
 
-// NewIssue creates an issue ready for saving to the issues table
-func NewIssue(moc, lccn, dt string, ed int) *Issue {
-	return &Issue{MARCOrgCode: moc, LCCN: lccn, Date: dt, Edition: ed, WorkflowStep: schema.WSAwaitingProcessing}
+// CreateIssueFromUpload is a single-purpose issue-builder just for storing an
+// issue which was queued via our uploads controller
+func CreateIssueFromUpload(moc, lccn, rawDate string, edition int, loc string, scanned bool) (*Issue, error) {
+	var issue = &Issue{
+		MARCOrgCode:   moc,
+		LCCN:          lccn,
+		Date:          rawDate,
+		Edition:       edition,
+		Location:      loc,
+		IsFromScanner: scanned,
+		WorkflowStep:  schema.WSAwaitingProcessing,
+	}
+	return issue, issue.Save(ActionTypeInternalProcess, SystemUser.ID, "Issue data initialized in NCA")
 }
 
 // IssueFinder is a pseudo-DSL for easily creating queries without needing to

--- a/src/models/moc_issue_aggregation.go
+++ b/src/models/moc_issue_aggregation.go
@@ -1,0 +1,83 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/schema"
+)
+
+// rawMOCIssueAggregation is our data model for the moc_issue_aggregation view.
+// This is a data-only model, and part of an ongoing effort to separate data
+// structures from business-logic structures.
+type rawMOCIssueAggregation struct {
+	ID           int64 `sql:",primary"`
+	Code         string
+	Name         string
+	WorkflowStep string
+	IssueCount   int64
+	TotalPages   int64
+}
+
+// rawMOCIssueAggregations returns the raw list of aggregated MOC data
+func rawMOCIssueAggregations() ([]*rawMOCIssueAggregation, error) {
+	var op = dbi.DB.Operation()
+	op.Dbg = dbi.Debug
+	var list []*rawMOCIssueAggregation
+	op.Select("moc_issue_aggregation", &rawMOCIssueAggregation{}).AllObjects(&list)
+	return list, op.Err()
+}
+
+// WorkflowCounts just holds the number of issues and pages aggregated for a
+// given MOC and workflow step
+type WorkflowCounts struct {
+	IssueCount int64
+	TotalPages int64
+}
+
+// IssueAggregation holds data representing a single organization's aggregate
+// issue and page counts, broken up by workflow step
+type IssueAggregation struct {
+	MOC    *MOC
+	Counts map[schema.WorkflowStep]WorkflowCounts
+}
+
+func newIssueAggregation(raw *rawMOCIssueAggregation) *IssueAggregation {
+	return &IssueAggregation{
+		MOC: &MOC{
+			ID:   raw.ID,
+			Code: raw.Code,
+			Name: raw.Name,
+		},
+		Counts: make(map[schema.WorkflowStep]WorkflowCounts),
+	}
+}
+
+// MOCIssueAggregations returns a list of aggregated data, one per Marc Org
+// Code, telling us a high-level view about the issues related to the given
+// MOC. No data is returned if the MOC has no associated issues.
+func MOCIssueAggregations() ([]*IssueAggregation, error) {
+	var rawList, err = rawMOCIssueAggregations()
+	if err != nil {
+		return nil, fmt.Errorf("reading raw MOC issue aggregations: %w", err)
+	}
+
+	var list []*IssueAggregation
+	var byID = make(map[int64]*IssueAggregation)
+	for _, rawAgg := range rawList {
+		var agg, ok = byID[rawAgg.ID]
+		if !ok {
+			agg = newIssueAggregation(rawAgg)
+			byID[rawAgg.ID] = agg
+			list = append(list, agg)
+		}
+
+		var ws = schema.WorkflowStep(rawAgg.WorkflowStep)
+		agg.Counts[ws] = WorkflowCounts{
+			IssueCount: rawAgg.IssueCount,
+			TotalPages: rawAgg.TotalPages,
+		}
+	}
+
+	return list, nil
+}

--- a/src/privilege/privilege.go
+++ b/src/privilege/privilege.go
@@ -29,6 +29,9 @@ var (
 	// the moment
 	SearchIssues = newPrivilege(RoleWorkflowManager)
 
+	// Generate new batches from the UI
+	GenerateBatches = newPrivilege(RoleBatchBuilder)
+
 	// View batch status: anybody who can see the batch status page, regardless
 	// of what they can/can't do there
 	ViewBatchStatus = newPrivilege(RoleBatchReviewer, RoleBatchLoader)

--- a/src/privilege/role.go
+++ b/src/privilege/role.go
@@ -43,6 +43,7 @@ var (
 		others which have been assigned to them.`)
 	RoleMOCManager      = newRole("marc org code manager", "Has access to add new MARC Org Codes")
 	RoleWorkflowManager = newRole("workflow manager", "Can queue SFTP and scanned issues for processing")
+	RoleBatchBuilder    = newRole("batch builder", "Can generate new batches on demand")
 	RoleBatchReviewer   = newRole("batch reviewer",
 		"Can view, reject, and approve batches which NCA has built but which are not yet in production.")
 	RoleBatchLoader = newRole("batch loader", "Can load and purge batches on staging and production. This role states the user has these abilities, but in NCA this really just means they can view and flag batches as being loaded / ready for QC.")

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -33,8 +33,8 @@
       <thead>
         <tr>
           <th scope="col">Select</th>
-          <th scope="col">Organization</th>
-          <th scope="col">Issue / Page Status</th>
+          <th scope="col">Ready for batching</th>
+          <th scope="col">Other issues</th>
         </tr>
       </thead>
 
@@ -43,22 +43,31 @@
         <tr>
           <td>
             <div class="form-check">
-              <input class="form-check-input" name="select-moc-{{.MOC.ID}}" id="select-moc-{{.MOC.ID}}" type="checkbox" />
+              <input class="form-check-input" name="moc" value="{{.MOC.ID}}" id="select-moc-{{.MOC.ID}}" type="checkbox" />
               <label class="form-check-label" for="select-moc-{{.MOC.ID}}">Select "{{.MOC.Code}}"</label>
             </div>
+            <em>{{.MOC.Name}}</em>
           </td>
 
-          <td>{{.MOC.Name}}</td>
+          <td>
+            {{pluralize "page" "pages" .ReadyForBatching.Pages}},
+            {{pluralize "issue" "issues" .ReadyForBatching.Len}}
+          </td>
 
           <td>
+            {{if .Counts}}
             <dl>
               {{range .Counts}}
               <dt>{{.Title}}</dt>
               <dd>
-                {{pluralize "issue" "issues" .Issues}}, {{pluralize "page" "pages" .Pages}}
+                {{pluralize "page" "pages" .Pages}},
+                {{pluralize "issue" "issues" .Issues}}
               </dd>
               {{end}}
             </dl>
+            {{else}}
+              No other issues are currently in NCA for this organization
+            {{end}}
           </td>
         </tr>
         {{end}}

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -11,33 +11,33 @@
           <th scope="col" data-sorttype="">Select</th>
           <th scope="col" data-sorttype="alpha">Institution</th>
           <th scope="col">Issue / Page Status</th>
-          <th scope="col" data-sorttype="date">Oldest Issue</th>
         </tr>
       </thead>
 
       <tbody>
+        {{range .Data.MOCIssueAggregations}}
         <tr>
           <td>
             <div class="form-check">
-              <input class="form-check-input" name="select-moc-1" id="select-moc-1" type="checkbox" />
-              <label class="form-check-label" for="select-moc-1">Select "oru"</label>
+              <input class="form-check-input" name="select-moc-{{.MOC.ID}}" id="select-moc-{{.MOC.ID}}" type="checkbox" />
+              <label class="form-check-label" for="select-moc-{{.MOC.ID}}">Select "{{.MOC.Code}}"</label>
             </div>
           </td>
 
-          <td>University of Oregon Libraries; Eugene, OR</td>
+          <td>{{.MOC.Name}}</td>
 
           <td>
             <dl>
-              <dt>Ready for batching</dt><dd>102 issues, 2305 pages</dd>
-              <dt>Processing</dt><dd>23 issues, 903 pages</dd>
-              <dt>Awaiting Metadata Review</dt><dd>2 issues, 20 pages</dd>
+              {{range $ws, $counts := .Counts}}
+              <dt>{{$ws}}</dt>
+              <dd>
+                {{pluralize "issue" "issues" $counts.IssueCount}}, {{pluralize "page" "pages" $counts.TotalPages}}
+              </dd>
+              {{end}}
             </dl>
           </td>
-
-          <td>
-            2021-09-23 (2y 1m)
-          </td>
         </tr>
+        {{end}}
       </tbody>
     </table>
 

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -3,13 +3,13 @@
 <h2>Batch Parameters</h2>
 
 <form action="{{BatchMakerFilterURL}}" class="row align-items-top" method="GET" role="search" aria-describedby="batch-form-help">
-  <div class="col-md-8">
+  <div class="col-md-12">
     <h2>Select Issues</h2>
-    <table class="table table-striped table-bordered table-condensed sortable">
+    <table class="table table-striped table-bordered table-condensed">
       <thead>
         <tr>
-          <th scope="col" data-sorttype="">Select</th>
-          <th scope="col" data-sorttype="alpha">Institution</th>
+          <th scope="col">Select</th>
+          <th scope="col">Organization</th>
           <th scope="col">Issue / Page Status</th>
         </tr>
       </thead>
@@ -28,10 +28,10 @@
 
           <td>
             <dl>
-              {{range $ws, $counts := .Counts}}
-              <dt>{{$ws}}</dt>
+              {{range .Counts}}
+              <dt>{{.Title}}</dt>
               <dd>
-                {{pluralize "issue" "issues" $counts.IssueCount}}, {{pluralize "page" "pages" $counts.TotalPages}}
+                {{pluralize "issue" "issues" .Issues}}, {{pluralize "page" "pages" .Pages}}
               </dd>
               {{end}}
             </dl>
@@ -46,7 +46,7 @@
     </div>
   </div>
 
-  <div id="batch-form-help" class="col-md-4">
+  <div id="batch-form-help" class="col-md-12">
     <h2>Help / Info</h2>
     <p>
       Choose one or more MARC org codes to build batches, and choose "Build

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -16,6 +16,12 @@
         batching.
       </li>
       <li>
+        A batch's "age" refers to how long its oldest issue has been ready for
+        batching. It's sometimes worth pushing a batch when one or more issues
+        have been waiting a long time, even if the batch is otherwise very
+        small.
+      </li>
+      <li>
         Open ONI's batches are grouped by "awardees" per the NDNP spec (MARC
         Org Codes are used to designate awardees). If multiple are selected,
         they will be batched individually even if your maximum batch size is
@@ -33,6 +39,7 @@
       <thead>
         <tr>
           <th scope="col">Select</th>
+          <th scope="col">Age</th>
           <th scope="col">Ready for batching</th>
           <th scope="col">Other issues</th>
         </tr>
@@ -47,6 +54,10 @@
               <label class="form-check-label" for="select-moc-{{.MOC.ID}}">Select "{{.MOC.Code}}"</label>
             </div>
             <em>{{.MOC.Name}}</em>
+          </td>
+
+          <td>
+            {{.Age}}
           </td>
 
           <td>

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -12,8 +12,8 @@
     <h2>Notes</h2>
     <ul>
       <li>
-        Embargoed issues are <strong>not</strong> included in the aggregate
-        counts, and will only be visible in the next step.
+        MARC Org Codes aren't displayed if they have no issues ready for
+        batching.
       </li>
       <li>
         Open ONI's batches are grouped by "awardees" per the NDNP spec (MARC

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -1,6 +1,30 @@
 {{block "content" .}}
 
-<h2>Batch Parameters</h2>
+<div id="batch-form-help" class="row align-items-top">
+  <div class="col-md-6">
+    <h2>Help / Info</h2>
+    Choose one or more MARC org codes to build batches, and choose "Build
+    Queues..." to see the list of issues you'll end up batching. Nothing is
+    created until you confirm the batch generation process.
+  </div>
+
+  <div class="col-md-6">
+    <h2>Notes</h2>
+    <ul>
+      <li>
+        Embargoed issues are <strong>not</strong> included in the aggregate
+        counts, and will only be visible in the next step.
+      </li>
+      <li>
+        Open ONI's batches are grouped by "awardees" per the NDNP spec (MARC
+        Org Codes are used to designate awardees). If multiple are selected,
+        they will be batched individually even if your maximum batch size is
+        large enough to accommodate all pages of all issues chosen.
+      </li>
+    </ul>
+  </div>
+
+</div>
 
 <form action="{{BatchMakerFilterURL}}" class="row align-items-top" method="GET" aria-describedby="batch-form-help">
   <div class="col-md-12">
@@ -44,28 +68,6 @@
     <div class="mb-3">
       <button class="btn btn-primary" type="submit">Build Queues...</button>
     </div>
-  </div>
-
-  <div id="batch-form-help" class="col-md-12">
-    <h2>Help / Info</h2>
-    <p>
-      Choose one or more MARC org codes to build batches, and choose "Build
-      Queues..." to see the list of issues you'll end up batching. Nothing is
-      created until you confirm the batch generation process.
-    </p>
-
-    <p>
-      Note that batches are grouped by "awardees" per the NDNP spec (MARC Org
-      Codes are used to designate awardees). If multiple are selected, they
-      will be batched individually even if your maximum batch size is large
-      enough to accommodate all pages of all issues chosen.
-    </p>
-
-    <p>
-      Note also that NCA and Open ONI allow custom / fake MARC org codes for
-      grouping batches and giving attribution to external entities that are not
-      necessarily NDNP awardees.
-    </p>
   </div>
 </form>
 

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -2,7 +2,7 @@
 
 <h2>Batch Parameters</h2>
 
-<form action="{{BatchMakerFilterURL}}" class="row align-items-top" method="GET" role="search" aria-describedby="batch-form-help">
+<form action="{{BatchMakerFilterURL}}" class="row align-items-top" method="GET" aria-describedby="batch-form-help">
   <div class="col-md-12">
     <h2>Select Issues</h2>
     <table class="table table-striped table-bordered table-condensed">

--- a/templates/batchmaker/build.go.html
+++ b/templates/batchmaker/build.go.html
@@ -1,0 +1,72 @@
+{{block "content" .}}
+
+<h2>Batch Parameters</h2>
+
+<form action="{{BatchMakerFilterURL}}" class="row align-items-top" method="GET" role="search" aria-describedby="batch-form-help">
+  <div class="col-md-8">
+    <h2>Select Issues</h2>
+    <table class="table table-striped table-bordered table-condensed sortable">
+      <thead>
+        <tr>
+          <th scope="col" data-sorttype="">Select</th>
+          <th scope="col" data-sorttype="alpha">Institution</th>
+          <th scope="col">Issue / Page Status</th>
+          <th scope="col" data-sorttype="date">Oldest Issue</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            <div class="form-check">
+              <input class="form-check-input" name="select-moc-1" id="select-moc-1" type="checkbox" />
+              <label class="form-check-label" for="select-moc-1">Select "oru"</label>
+            </div>
+          </td>
+
+          <td>University of Oregon Libraries; Eugene, OR</td>
+
+          <td>
+            <dl>
+              <dt>Ready for batching</dt><dd>102 issues, 2305 pages</dd>
+              <dt>Processing</dt><dd>23 issues, 903 pages</dd>
+              <dt>Awaiting Metadata Review</dt><dd>2 issues, 20 pages</dd>
+            </dl>
+          </td>
+
+          <td>
+            2021-09-23 (2y 1m)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="mb-3">
+      <button class="btn btn-primary" type="submit">Build Queues...</button>
+    </div>
+  </div>
+
+  <div id="batch-form-help" class="col-md-4">
+    <h2>Help / Info</h2>
+    <p>
+      Choose one or more MARC org codes to build batches, and choose "Build
+      Queues..." to see the list of issues you'll end up batching. Nothing is
+      created until you confirm the batch generation process.
+    </p>
+
+    <p>
+      Note that batches are grouped by "awardees" per the NDNP spec (MARC Org
+      Codes are used to designate awardees). If multiple are selected, they
+      will be batched individually even if your maximum batch size is large
+      enough to accommodate all pages of all issues chosen.
+    </p>
+
+    <p>
+      Note also that NCA and Open ONI allow custom / fake MARC org codes for
+      grouping batches and giving attribution to external entities that are not
+      necessarily NDNP awardees.
+    </p>
+  </div>
+</form>
+
+{{end}}

--- a/templates/batchmaker/generate-form.go.html
+++ b/templates/batchmaker/generate-form.go.html
@@ -1,0 +1,95 @@
+{{block "content" .}}
+
+<h2>
+  {{if eq 4 (len .Data.Queues)}}
+  There... are... <em>four</em> <del>lights</del> batches ready for creation
+  {{else}}
+  There are {{pluralize "batch" "batches" (len .Data.Queues)}} ready for creation
+  {{end}}
+</h2>
+
+<div class="row">
+  <div class="col-md-6">
+    <ul>
+      {{range .Data.Queues}}
+      <li>
+        {{.MOC.Code}} queue number {{.Sequence}}:
+        {{pluralize "page" "pages" .Queue.Pages}} across {{pluralize "issue" "issues" .Queue.Len}}
+      </li>
+      {{end}}
+    </ul>
+  </div>
+
+  <div class="col-md-6">
+    <p class="alert alert-info">
+      Note that, while unlikely, it's possible that this may change if issues get
+      moved into a "ready for batching" state before you choose to generate
+      batches. This data is a snapshot of the current state of the issues, not a
+      final list!
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <form action="{{BatchMakerGenerateURL}}" class="col-auto" method="POST">
+    {{range .Data.MOCIssueAggregations}}
+    <input type="hidden" name="moc" value="{{.MOC.ID}}" />
+    {{end}}
+    <input type="hidden" name="maxpages" id="maxpages" value="{{.Data.MaxPages}}" />
+    <input type="hidden" name="verified" value="1" />
+
+    <button class="btn btn-primary" type="submit">Make It So!</button>
+  </form>
+
+  <form action="{{BatchMakerFilterURL}}" class="col-auto" method="GET">
+    {{range .Data.MOCIssueAggregations}}
+    <input type="hidden" name="moc" value="{{.MOC.ID}}" />
+    {{end}}
+    <input type="hidden" name="maxpages" id="maxpages" value="{{.Data.MaxPages}}" />
+    <button class="btn btn-danger" type="submit">Belay That Order!</button>
+  </form>
+</div>
+
+<h2>Issue Breakdown</h2>
+
+<p>
+  Before submitting, you can review the aggregate data again to be sure you are
+  batching what you want.
+</p>
+
+<div class="row">
+{{range .Data.MOCIssueAggregations}}
+<div class="col-md-6">
+<div class="card">
+  <div class="card-header">
+    <h3>{{.MOC.Code}} ({{.MOC.Name}})</h3>
+  </div>
+  <div class="card-body">
+    <div class="card-title">
+      <strong>{{pluralize "page" "pages" .ReadyForBatching.Pages}} across {{pluralize "issue"
+      "issues" .ReadyForBatching.Len}} will be queued for batching.</strong>
+    </div>
+
+    <div class="card-body">
+      <p>Other issues:</p>
+      {{if .Counts}}
+      <dl>
+        {{range .Counts}}
+        <dt>{{.Title}}</dt>
+        <dd>
+          {{pluralize "page" "pages" .Pages}},
+          {{pluralize "issue" "issues" .Issues}}
+        </dd>
+        {{end}}
+      </dl>
+      {{else}}
+        No other issues are currently in NCA for this organization
+      {{end}}
+    </div>
+  </div>
+</div>
+</div>
+{{end}}
+</div>
+
+{{end}}

--- a/templates/batchmaker/show-issues.go.html
+++ b/templates/batchmaker/show-issues.go.html
@@ -1,0 +1,63 @@
+{{block "content" .}}
+
+<h2>Issue Breakdown</h2>
+
+<div class="row">
+{{range .Data.MOCIssueAggregations}}
+<div class="col-md-6">
+<div class="card">
+  <div class="card-header">
+    <h3>{{.MOC.Code}} ({{.MOC.Name}})</h3>
+  </div>
+  <div class="card-body">
+    <div class="card-title">
+      <strong>{{pluralize "page" "pages" .ReadyForBatching.Pages}} across {{pluralize "issue"
+      "issues" .ReadyForBatching.Len}} will be queued for batching.</strong>
+    </div>
+
+    <div class="card-body">
+      <p>Other issues:</p>
+      {{if .Counts}}
+      <dl>
+        {{range .Counts}}
+        <dt>{{.Title}}</dt>
+        <dd>
+          {{pluralize "page" "pages" .Pages}},
+          {{pluralize "issue" "issues" .Issues}}
+        </dd>
+        {{end}}
+      </dl>
+      {{else}}
+        No other issues are currently in NCA for this organization
+      {{end}}
+    </div>
+  </div>
+</div>
+</div>
+{{end}}
+</div>
+
+<h2>Finalize Batch(es)</h2>
+
+<div id="generate-batch-help">
+  <p>
+    Choose a maximum batch size, and "Generate" to continue. Queues will be split
+    up as evenly as possible to match the requested maximum batch size while
+    ensuring no issues are split across two batches.
+  </p>
+</div>
+
+<form action="{{BatchMakerGenerateURL}}" class="row align-items-top" method="GET" aria-describedby="generate-batch-help">
+  {{range .Data.MOCIssueAggregations}}
+  <input type="hidden" name="moc" value="{{.MOC.ID}}" />
+  {{end}}
+  <label class="col-auto col-form-label" for="maxpages">Maximum Batch Size (pages)</label>
+  <div class="col-auto">
+    <input class="form-control" type="number" name="maxpages" id="maxpages" 
+      {{if .Data.MaxPages}}value="{{.Data.MaxPages}}"{{end}} />
+  </div>
+
+  <button class="col-auto btn btn-primary" type="submit">Preview...</button>
+</form>
+
+{{end}}

--- a/templates/layout.go.html
+++ b/templates/layout.go.html
@@ -44,7 +44,11 @@
             {{end}}
 
             {{if .User.PermittedTo ViewBatchStatus}}
-            <li class="nav-item"><a class="nav-link" href="{{FullPath "batches"}}">Batches</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{FullPath "batches"}}">Manage Batches</a></li>
+            {{end}}
+
+            {{if .User.PermittedTo GenerateBatches}}
+            <li class="nav-item"><a class="nav-link" href="{{FullPath "batchmaker"}}">Create Batches</a></li>
             {{end}}
 
             {{if .User.PermittedTo ViewMetadataWorkflow}}


### PR DESCRIPTION
Closes #220 

Refactors batch generation in order to allow for command-line *or* web admin batch generation. Creates a new section in NCA's web interface for doing batch generation on demand, and a new role for who is allowed to do this.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>