### PR TITLE
Add tabbed UI to batch management

### DIFF
--- a/changelogs/2024-09-10-batch-tabs.md
+++ b/changelogs/2024-09-10-batch-tabs.md
@@ -1,0 +1,9 @@
+### Added
+
+- Users with some kind of batch-related role can now see most batches, even if
+  they can't take any actions
+
+### Changed
+
+- The "Batch Management" view groups batches in tabs so the ones that need the
+  most immediate attention are easier to find

--- a/src/cmd/server/internal/batchhandler/can.go
+++ b/src/cmd/server/internal/batchhandler/can.go
@@ -1,7 +1,6 @@
 package batchhandler
 
 import (
-	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/logger"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/privilege"
 )
@@ -28,24 +27,7 @@ func (c *CanValidation) View() bool {
 		return true
 	}
 
-	var has = c.user.PermittedTo
-	switch c.batch.Status {
-	case models.BatchStatusStagingReady:
-		return has(privilege.LoadBatches)
-	case models.BatchStatusQCReady:
-		return has(privilege.ViewQCReadyBatches)
-	case models.BatchStatusQCFlagIssues:
-		return has(privilege.RejectQCReadyBatches)
-	case models.BatchStatusPassedQC:
-		return has(privilege.LoadBatches)
-	case models.BatchStatusLive:
-		return has(privilege.ArchiveBatches)
-	case models.BatchStatusDeleted, models.BatchStatusPending, models.BatchStatusLiveDone, models.BatchStatusLiveArchived:
-		return false
-	}
-
-	logger.Errorf("Can view batch: Unhandled status %q", c.batch.Status)
-	return false
+	return c.batch.Status != models.BatchStatusDeleted && c.batch.Status != models.BatchStatusPending
 }
 
 // Load is true if the user can load batches *and* batch is in a loadable state

--- a/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
+++ b/src/cmd/server/internal/batchhandler/flag_issues_handlers.go
@@ -54,7 +54,7 @@ func prepFlagging(w http.ResponseWriter, req *http.Request) (r *Responder, ok bo
 	if !ok {
 		return r, false
 	}
-	if !r.can.FlagIssues(r.batch) {
+	if !r.batch.Can().FlagIssues() {
 		r.Error(http.StatusForbidden, "You are not permitted to flag issues for removal from this batch")
 		return r, false
 	}
@@ -264,7 +264,7 @@ func finalizeBatch(r *Responder) {
 }
 
 func purgeBatch(r *Responder) {
-	if !r.can.Purge(r.batch) {
+	if !r.batch.Can().Purge() {
 		r.Error(http.StatusForbidden, "You are not permitted to purge this batch")
 		return
 	}

--- a/src/cmd/server/internal/batchhandler/handlers.go
+++ b/src/cmd/server/internal/batchhandler/handlers.go
@@ -37,7 +37,7 @@ func setStatus(r *Responder, status string, action models.ActionType, t *tmpl.Te
 func listHandler(w http.ResponseWriter, req *http.Request) {
 	var r = responder.Response(w, req)
 	r.Vars.Title = "Batches"
-	var list, err = models.InProcessBatches()
+	var list, err = models.ActionableBatches()
 	if err != nil {
 		logger.Criticalf("Unable to load batches: %s", err)
 		r.Error(http.StatusInternalServerError, "Error trying to pull batch list - try again or contact support")

--- a/src/cmd/server/internal/batchhandler/handlers.go
+++ b/src/cmd/server/internal/batchhandler/handlers.go
@@ -52,9 +52,9 @@ func listHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Break batches into groups: not live, live but not done (live /
-	// live_archived), and done (live_done). The latter is its own group because
-	// it's a huge list that, most of the time, we don't need to browse.
+	// Break batches into groups: not live, live, archived but not complete, and
+	// completed. The latter is its own group because it's a huge list that, most
+	// of the time, we don't need to browse.
 	var inproc, live, archived, complete []*Batch
 	for _, b := range wrapped {
 		// Immediately skip anything the current user can't even view

--- a/src/cmd/server/internal/batchhandler/handlers.go
+++ b/src/cmd/server/internal/batchhandler/handlers.go
@@ -44,13 +44,12 @@ func listHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	r.Vars.Data["Batches"], err = wrapBatches(list)
+	r.Vars.Data["Batches"], err = wrapBatches(list, r.Vars.User)
 	if err != nil {
 		logger.Criticalf("Unable to wrap batches: %s", err)
 		r.Error(http.StatusInternalServerError, "Error trying to pull batch list - try again or contact support")
 		return
 	}
-	r.Vars.Data["Can"] = Can(r.Vars.User)
 	r.Render(listTmpl)
 }
 
@@ -59,7 +58,7 @@ func viewHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.View(r.batch) {
+	if !r.batch.Can().View() {
 		r.Error(http.StatusForbidden, "You are not permitted to view this batch")
 		return
 	}
@@ -72,7 +71,7 @@ func qcReadyHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Load(r.batch) {
+	if !r.batch.Can().Load() {
 		r.Error(http.StatusForbidden, "You are not permitted to load batches or flag them for having been loaded")
 		return
 	}
@@ -89,7 +88,7 @@ func qcApproveFormHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Approve(r.batch) {
+	if !r.batch.Can().Approve() {
 		r.Error(http.StatusForbidden, "You are not permitted to approve this batch for a production load")
 		return
 	}
@@ -103,7 +102,7 @@ func qcApproveHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Approve(r.batch) {
+	if !r.batch.Can().Approve() {
 		r.Error(http.StatusForbidden, "You are not permitted to approve this batch for a production load")
 		return
 	}
@@ -137,7 +136,7 @@ func clearBatchStagingPurgeFlagHandler(w http.ResponseWriter, req *http.Request)
 	if !ok {
 		return
 	}
-	if !r.can.Load(r.batch) {
+	if !r.batch.Can().Load() {
 		r.Error(http.StatusForbidden, "You are not permitted to reject this batch")
 		return
 	}
@@ -166,7 +165,7 @@ func setLiveHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Load(r.batch) {
+	if !r.batch.Can().Load() {
 		r.Error(http.StatusForbidden, "You are not permitted to load batches or flag them for having been loaded")
 		return
 	}
@@ -196,7 +195,7 @@ func setArchivedHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Archive(r.batch) {
+	if !r.batch.Can().Archive() {
 		r.Error(http.StatusForbidden, "You are not permitted to flag batches as having been archived")
 		return
 	}
@@ -228,7 +227,7 @@ func qcRejectFormHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Reject(r.batch) {
+	if !r.batch.Can().Reject() {
 		r.Error(http.StatusForbidden, "You are not permitted to reject this batch")
 		return
 	}
@@ -242,7 +241,7 @@ func qcRejectHandler(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
-	if !r.can.Reject(r.batch) {
+	if !r.batch.Can().Reject() {
 		r.Error(http.StatusForbidden, "You are not permitted to reject this batch")
 		return
 	}

--- a/src/cmd/server/internal/batchhandler/responder.go
+++ b/src/cmd/server/internal/batchhandler/responder.go
@@ -16,7 +16,6 @@ import (
 type Responder struct {
 	*responder.Responder
 	batch *Batch
-	can   *CanValidation
 }
 
 // getBatchResponder centralizes the most common handler logic where we require
@@ -42,7 +41,7 @@ func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, 
 		return r, false
 	}
 
-	r.batch, err = wrapBatch(b)
+	r.batch, err = wrapBatch(b, r.Vars.User)
 	if err != nil {
 		logger.Criticalf("Error reading flagged issues for batch %d (%s): %s", r.batch.ID, r.batch.Name, err)
 		r.Error(http.StatusInternalServerError, "Error trying to read batch's issues - try again or contact support")
@@ -52,8 +51,6 @@ func getBatchResponder(w http.ResponseWriter, req *http.Request) (r *Responder, 
 	r.Vars.Data["Actions"] = r.batch.Actions
 	r.Vars.Data["FlaggedIssues"] = r.batch.FlaggedIssues
 	r.Vars.Data["UnflaggedIssues"] = r.batch.UnflaggedIssues
-	r.can = Can(r.Vars.User)
 	r.Vars.Data["Batch"] = r.batch
-	r.Vars.Data["Can"] = r.can
 	return r, true
 }

--- a/src/cmd/server/internal/batchhandler/schema.go
+++ b/src/cmd/server/internal/batchhandler/schema.go
@@ -66,12 +66,6 @@ func wrapBatches(list []*models.Batch, currentUser *models.User) ([]*Batch, erro
 	return batches, nil
 }
 
-// Unavailable returns true if the batch status indicates it's not currently
-// able to be acted upon by users (doesn't need action)
-func (b *Batch) Unavailable() bool {
-	return !b.StatusMeta.NeedsAction
-}
-
 // ReadyForStaging is true if the batch is ready to be loaded onto staging
 func (b *Batch) ReadyForStaging() bool {
 	return b.Status == models.BatchStatusStagingReady

--- a/src/models/batch.go
+++ b/src/models/batch.go
@@ -156,12 +156,14 @@ func FindBatch(id int64) (*Batch, error) {
 	return list[0], err
 }
 
-// InProcessBatches returns the full list of in-process batches (not live, not pending)
-func InProcessBatches() ([]*Batch, error) {
+// ActionableBatches returns the full list of batches that can have some kind
+// of action on them, including "live_done" batches that can only be pulled
+// from prod.
+func ActionableBatches() ([]*Batch, error) {
 	var statusList []any
 	var placeholders []string
 	for status, data := range statusMap {
-		if data.NeedsAction {
+		if data.Live || data.Staging || data.NeedsAction {
 			statusList = append(statusList, status)
 			placeholders = append(placeholders, "?")
 		}

--- a/src/models/batch.go
+++ b/src/models/batch.go
@@ -29,7 +29,6 @@ type BatchStatus struct {
 	Status      string
 	Live        bool
 	Staging     bool
-	Dead        bool
 	NeedsAction bool
 	Description string
 }
@@ -41,7 +40,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusPending,
 		Live:        false,
 		Staging:     false,
-		Dead:        false,
 		NeedsAction: false,
 		Description: "Pending: build job is scheduled but hasn't yet run",
 	},
@@ -49,7 +47,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusStagingReady,
 		Live:        false,
 		Staging:     false,
-		Dead:        false,
 		NeedsAction: true,
 		Description: "Ready for ingest onto staging server",
 	},
@@ -57,7 +54,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusQCReady,
 		Live:        false,
 		Staging:     true,
-		Dead:        false,
 		NeedsAction: true,
 		Description: "On staging, awaiting quality control check",
 	},
@@ -65,7 +61,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusQCFlagIssues,
 		Live:        false,
 		Staging:     true,
-		Dead:        false,
 		NeedsAction: true,
 		Description: "Failed quality control, awaiting QC issue flagging",
 	},
@@ -73,7 +68,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusDeleted,
 		Live:        false,
 		Staging:     false,
-		Dead:        true,
 		NeedsAction: false,
 		Description: "Removed from the system.  Likely rebuilt under a new name.",
 	},
@@ -81,7 +75,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusPassedQC,
 		Live:        false,
 		Staging:     true,
-		Dead:        false,
 		NeedsAction: true,
 		Description: "Passed quality control, awaiting batch maintainer to load on production",
 	},
@@ -89,7 +82,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusLive,
 		Live:        true,
 		Staging:     false,
-		Dead:        false,
 		NeedsAction: true,
 		Description: "Live in production, awaiting archiving",
 	},
@@ -97,7 +89,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusLiveArchived,
 		Live:        true,
 		Staging:     false,
-		Dead:        false,
 		NeedsAction: false,
 		Description: "Live in production and archived: awaiting local file cleanup",
 	},
@@ -105,7 +96,6 @@ var statusMap = map[string]BatchStatus{
 		Status:      BatchStatusLiveDone,
 		Live:        true,
 		Staging:     false,
-		Dead:        false,
 		NeedsAction: false,
 		Description: "Live in production and archived: no longer available in NCA workflow",
 	},

--- a/templates/batches/flag_issues_form.go.html
+++ b/templates/batches/flag_issues_form.go.html
@@ -97,7 +97,7 @@
         </div>
       </cta-modal>
 
-      {{if .Data.Can.Purge .Data.Batch}}
+      {{if .Data.Batch.Can.Purge}}
       <cta-modal>
         <div slot="button" class="inline">
           {{if ne 0 .Data.RemainingIssues}}

--- a/templates/batches/list.go.html
+++ b/templates/batches/list.go.html
@@ -3,7 +3,7 @@
 <h2>Batches needing attention</h2>
 
 {{if .Data.Batches}}
-{{template "batch-table" .}}
+{{template "batch-table" .Data.Batches}}
 {{else}}
 There are no batches currently in need of any action!
 {{end}}
@@ -23,8 +23,8 @@ There are no batches currently in need of any action!
   </thead>
 
   <tbody>
-  {{range .Data.Batches}}
-  {{if $.Data.Can.View .}}
+  {{range .}}
+  {{if .Can.View}}
   <tr>
     <th scope="row"><a href="{{ViewURL .}}">{{.Name}}</a></th>
     <td>

--- a/templates/batches/list.go.html
+++ b/templates/batches/list.go.html
@@ -2,11 +2,95 @@
 
 <h2>Batches needing attention</h2>
 
-{{if .Data.Batches}}
-{{template "batch-table" .Data.Batches}}
-{{else}}
-There are no batches currently in need of any action!
-{{end}}
+<p>
+  In-process batches are listed in a single group for simplicity: most of the
+  time, these are the batches people will work with. Other tabs, when
+  available, include batches of only the relevant status, and are primarily
+  here for batch archiving work or post-live batch corrections, not general
+  workflows.
+<p>
+  Note: while most batch-related roles allow viewing all batches, many are
+  read-only. If a batch is awaiting an ingest onto staging, and your role is
+  quality control, for instance, you can view it, but there won't be anything
+  listed in its "Actions" pane.
+</p>
+
+<div class="tabs">
+  <div role="tablist" aria-label="Batch Workflow">
+    <!-- We always show this tab, even when nothing is here, so the app doesn't look broken -->
+    <button role="tab" aria-selected="false" aria-controls="in-process-panel" id="in-process-tab">
+      <h3>
+        In Process
+      </h3>
+    </button>
+
+    {{if .Data.Live}}
+    <button role="tab" aria-selected="false" aria-controls="live-panel" id="live-tab">
+      <h3>
+        Live
+      </h3>
+    </button>
+    {{end}}
+
+    {{if .Data.Archived}}
+    <button role="tab" aria-selected="false" aria-controls="archived-panel" id="archived-tab">
+      <h3>
+        Archived
+      </h3>
+    </button>
+    {{end}}
+
+    {{if .Data.Complete}}
+    <button role="tab" aria-selected="false" aria-controls="complete-panel" id="complete-tab">
+      <h3>
+        Complete
+      </h3>
+    </button>
+    {{end}}
+  </div>
+
+  <!-- We always show this panel, even when nothing is here, so the app doesn't look broken -->
+  <div tabindex="0" role="tabpanel" id="in-process-panel" aria-labelledby="in-process-tab" hidden="">
+    <p>
+      In-process batches include any batch within NCA that currently need attention
+      of some kind: QC, loading the batch into ONI, etc.
+    </p>
+    {{if .Data.InProcess}}
+    {{template "batch-table" dict "Batches" .Data.InProcess "ShowStatus" true}}
+    {{else}}
+    <p><em>There are currently no batches requiring your attention.</em></p>
+    {{end}}
+  </div>
+
+  {{if .Data.Live}}
+  <div tabindex="0" role="tabpanel" id="live-panel" aria-labelledby="live-tab" hidden="">
+    <p>
+      These batches are on production, but not archived. Their files are still in NCA.
+    </p>
+    {{template "batch-table" dict "Batches" .Data.Live "ShowStatus" false}}
+  </div>
+  {{end}}
+
+  {{if .Data.Archived}}
+  <div tabindex="0" role="tabpanel" id="archived-panel" aria-labelledby="archived-tab" hidden="">
+    <p>
+      Archived batches are on production and have been archived, but files
+      haven't yet been cleaned up from NCA.
+    </p>
+    {{template "batch-table" dict "Batches" .Data.Archived "ShowStatus" false}}
+  </div>
+  {{end}}
+
+  {{if .Data.Complete}}
+  <div tabindex="0" role="tabpanel" id="complete-panel" aria-labelledby="complete-tab" hidden="">
+    <p>
+      These batches are on production and their files are fully archived and backed
+      up, no longer visible to NCA directly.
+    </p>
+    {{template "batch-table" dict "Batches" .Data.Complete "ShowStatus" false}}
+  </div>
+  {{end}}
+</div>
 
 {{end}}
 
@@ -15,7 +99,9 @@ There are no batches currently in need of any action!
   <thead>
     <tr>
       <th scope="col" data-sorttype="alpha">Name</th>
+      {{if $.ShowStatus}}
       <th scope="col" data-sorttype="alpha">Status</th>
+      {{end}}
       <th scope="col" data-sorttype="alpha">MOC</th>
       <th scope="col" data-sorttype="number">Pages</th>
       <th scope="col" data-sorttype="date">Created</th>
@@ -23,19 +109,19 @@ There are no batches currently in need of any action!
   </thead>
 
   <tbody>
-  {{range .}}
-  {{if .Can.View}}
+  {{range .Batches}}
   <tr>
     <th scope="row"><a href="{{ViewURL .}}">{{.Name}}</a></th>
+    {{if $.ShowStatus}}
     <td>
       <code>{{.Status}}</code>:
       {{.StatusMeta.Description}}
     </td>
+    {{end}}
     <td>{{.MARCOrgCode}}</td>
     <td>{{pluralize "page" "pages" .PageCount}} ({{pluralize "issue" "issues" (len .Issues)}})</td>
     <td>{{.CreatedAt.Format "2006-01-02"}}</td>
   </tr>
-  {{end}}
   {{end}}
   </tbody>
 </table>

--- a/templates/batches/view.go.html
+++ b/templates/batches/view.go.html
@@ -13,7 +13,7 @@
     <strong>This batch is not in a state that allows user actions</strong>
 
     <!-- Batch needs to be purged from staging: this overrides all other considerations -->
-    {{else if and .Data.Batch.NeedStagingPurge (.Data.Can.Load .Data.Batch)}}
+    {{else if and .Data.Batch.NeedStagingPurge .Data.Batch.Can.Load}}
     <p><strong>{{.Data.Batch.Name}} needs to be purged from staging. This is a manual process.</strong></p>
     <p>Purge the batch <em>from staging</em>:</p>
     {{template "batch-manual-purge" .Data.Batch}}
@@ -24,7 +24,7 @@
     </form>
 
     <!-- Batch needs to be pushed to staging -->
-    {{else if and .Data.Batch.ReadyForStaging (.Data.Can.Load .Data.Batch)}}
+    {{else if and .Data.Batch.ReadyForStaging .Data.Batch.Can.Load}}
     <p><strong>{{.Data.Batch.Name}} is ready to be loaded onto staging. This is a manual process.</strong></p>
     <p>Load the batch <em>onto staging</em>:</p>
     {{template "batch-manual-load" .Data.Batch}}
@@ -35,14 +35,14 @@
     </form>
 
     <!-- Needs QC pass -->
-    {{else if and .Data.Batch.ReadyForQC (.Data.Can.Approve .Data.Batch)}}
+    {{else if and .Data.Batch.ReadyForQC .Data.Batch.Can.Approve}}
     <p>{{.Data.Batch.Name}} needs approval to move to production (or a rejection if it needs to be fixed).</p>
 
     <a href="{{ApproveURL .Data.Batch}}" class="btn btn-primary">Approve...</a>
     <a href="{{RejectURL .Data.Batch}}" class="btn btn-danger">Reject...</a>
 
     <!-- Needs batch reviewer to flag issues -->
-    {{else if and .Data.Batch.ReadyForFlaggingIssues (.Data.Can.FlagIssues .Data.Batch)}}
+    {{else if and .Data.Batch.ReadyForFlaggingIssues .Data.Batch.Can.FlagIssues}}
     <p>
       {{.Data.Batch.Name}} has failed QC. You can mark issues that need to be
       removed and then send the batch back to staging, or eliminate the batch
@@ -52,7 +52,7 @@
     <a href="{{FlagIssuesURL .Data.Batch}}" class="btn btn-primary">Flag Issues / Purge Batch...</a>
 
     <!-- Needs production load -->
-    {{else if and .Data.Batch.ReadyForProduction (.Data.Can.Load .Data.Batch)}}
+    {{else if and .Data.Batch.ReadyForProduction .Data.Batch.Can.Load}}
     <p><strong>{{.Data.Batch.Name}} is ready to be loaded onto production. This is a manual process.</strong></p>
     <p>
       Load the batch <em>on production</em>:
@@ -66,7 +66,7 @@
 
     <!-- On production, copied to archive location, needs to be flagged for the
          issue-cleanup countdown to start -->
-    {{else if and .Data.Batch.ReadyForArchive (.Data.Can.Archive .Data.Batch)}}
+    {{else if and .Data.Batch.ReadyForArchive .Data.Batch.Can.Archive}}
     <p><strong>{{.Data.Batch.Name}} is live and has been copied to the archival location.</strong></p>
     <p>
       When the archive has been finalized, flag it as complete below. This starts

--- a/templates/batches/view.go.html
+++ b/templates/batches/view.go.html
@@ -85,6 +85,8 @@
       <button class="btn btn-primary" type="submit">Mark Batch "Archived"</button>
     </form>
 
+    {{else}}
+    <p>There are currently no actions you can take on this batch.</p>
     {{end}}
   </div>
 </div>

--- a/templates/batches/view.go.html
+++ b/templates/batches/view.go.html
@@ -86,8 +86,6 @@
     </form>
 
     {{end}}
-
-    <!-- TODO: other statuses -->
   </div>
 </div>
 

--- a/templates/batches/view.go.html
+++ b/templates/batches/view.go.html
@@ -8,12 +8,8 @@
   <div class="col-md-6">
     <h2>Actions</h2>
 
-    <!-- Batch has no actions -->
-    {{if .Data.Batch.Unavailable}}
-    <strong>This batch is not in a state that allows user actions</strong>
-
     <!-- Batch needs to be purged from staging: this overrides all other considerations -->
-    {{else if and .Data.Batch.NeedStagingPurge .Data.Batch.Can.Load}}
+    {{if and .Data.Batch.NeedStagingPurge .Data.Batch.Can.Load}}
     <p><strong>{{.Data.Batch.Name}} needs to be purged from staging. This is a manual process.</strong></p>
     <p>Purge the batch <em>from staging</em>:</p>
     {{template "batch-manual-purge" .Data.Batch}}


### PR DESCRIPTION
Related to #330

Adds tabs for batch management so it's easier to see which batches are in what part of their lifecycle. Changes permissions to allow viewing pretty much any batch by anybody with a batch-related role.

This must not merge until after v5.0.0 is live.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [ ] Documentation has been updated as necessary (`hugo/content/`)
