### PR TITLE
privilege: allow batch builder to be assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ Brief description, if necessary
 ### Migration
 -->
 
+## v5.0.1
+
+Batching is now *allowed*! WOW!
+
+### Fixed
+
+- Users can now be properly assigned the "Batch Builder" role. Previously, only
+  admins could generate batches.
+
 ## v5.0.0
 
 Batching and Boostrap 5.

--- a/src/privilege/role.go
+++ b/src/privilege/role.go
@@ -62,6 +62,7 @@ var AssignableRoles = []*Role{
 	RoleUserManager,
 	RoleMOCManager,
 	RoleWorkflowManager,
+	RoleBatchBuilder,
 	RoleBatchReviewer,
 	RoleBatchLoader,
 }


### PR DESCRIPTION
Fixes v5.0.0 bug where nobody could get the new Batch Builder role. (Administrators have all privileges, so this didn't seem like a problem in our case, as admins are the ones who would build batches)

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>