### PR TITLE
Feature/test users

### DIFF
--- a/changelogs/2024-09-10-test-users.md
+++ b/changelogs/2024-09-10-test-users.md
@@ -1,0 +1,10 @@
+### Added
+
+- New script for testing, `test/create-test-users.go`, which deletes existing
+  users and then creates a new user for each role in NCA
+
+### Changed
+
+- When running `prep_for_testing`, migration-installed users will be destroyed
+  and replaced with role-based users. If you tend to test as "admin", nothing
+  will appear to change, but the "sysadmin" user will no longer be available.

--- a/scripts/localdev.sh
+++ b/scripts/localdev.sh
@@ -23,7 +23,7 @@ wait_for_database() {
 resetdb() {
   docker compose down -v
   docker compose up -d db iiif sftpgo
-  wait_for_database && migrate && load_seed_data
+  wait_for_database && migrate && load_seed_data && create_test_users
 }
 
 _get_bulk_lccns() {
@@ -75,6 +75,13 @@ migrate() {
 
 load_seed_data() {
   mysql -unca -pnca -Dnca -h127.0.0.1 < ./docker/mysql/nca-seed-data.sql
+}
+
+create_test_users() {
+  pushd .
+  cd ./test
+  go run create-test-users.go -c ../settings
+  popd
 }
 
 upload_server() {

--- a/test/create-test-users.go
+++ b/test/create-test-users.go
@@ -1,0 +1,53 @@
+//go:build ignore
+
+// create-test-users.go deletes all existing users from the database, then
+// iterates over all assignable roles and creates a single-role user for each
+// of them
+
+package main
+
+import (
+	"strings"
+
+	"github.com/uoregon-libraries/gopkg/logger"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/cli"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/config"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/dbi"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/privilege"
+)
+
+var conf *config.Config
+
+var opts cli.BaseOptions
+var l = logger.New(logger.Debug, false)
+
+func getOpts() {
+	var c = cli.New(&opts)
+	conf = c.GetConf()
+
+	var err = dbi.DBConnect(conf.DatabaseConnect)
+	if err != nil {
+		l.Fatalf("Error trying to connect to database: %s", err)
+	}
+}
+
+func main() {
+	getOpts()
+
+	var op = dbi.DB.Operation()
+	var result = op.Exec("DELETE FROM users")
+	if result.Err() != nil {
+		l.Fatalf("Error deleting existing users: %s", result.Err())
+	}
+
+	for _, role := range privilege.AssignableRoles {
+		var u = &models.User{Login: strings.ToLower(strings.Replace(role.Name, " ", "", -1))}
+		u.Grant(role)
+		l.Debugf("Creating user named %q with role %q", u.Login, role.Name)
+		var err = u.Save()
+		if err != nil {
+			l.Fatalf("Error saving user for role %#v: %s", role, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #334 

Adds a new command to create users per role for testing, runs command automatically in `prep_for_testing` function

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>
