### PR TITLE
Rename "purge" related code and docs

### DIFF
--- a/changelogs/2024-09-30-stop-overusing-purge.md
+++ b/changelogs/2024-09-30-stop-overusing-purge.md
@@ -1,0 +1,12 @@
+### Changed
+
+- Most areas of NCA that used the term "purge", when referring to something
+  other than the purging of a batch from ONI, have changed to some other term.
+  This requires a migration (see notes below) to keep the database meaningful.
+
+### Migration
+
+- Shut down NCA workers and HTTP daemon
+- Run database migrations:
+  - `make && ./bin/migrate-database -c ./settings up`
+- Restart services

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -40,12 +40,7 @@ else
 fi
 
 echo Copying in the new stuff
-sudo cp $src/bin/server $ncadir/
-sudo cp $src/bin/run-jobs $ncadir/
-sudo cp $src/bin/queue-batches $ncadir/
-sudo cp $src/bin/bulk-issue-queue $ncadir/
-sudo cp $src/bin/delete-live-done-issues $ncadir/
-sudo cp $src/bin/purge-dead-issues $ncadir/
+sudo cp $src/bin/* $ncadir/
 sudo cp $src/deploy/nca-httpd.service $ncadir/
 sudo cp $src/deploy/nca-workers.service $ncadir/
 sudo cp $src/deploy/nca-rsyslog.conf /etc/rsyslog.d/nca.conf

--- a/hugo/content/setup/server-setup.md
+++ b/hugo/content/setup/server-setup.md
@@ -35,7 +35,7 @@ Before anything can be done, the following setup has to happen:
    - `SCAN_UPLOAD_PATH` (`/mnt/news/scans`): This is where in-house scans would be uploaded.
    - `ORIGINAL_PDF_BACKUP_PATH` (`/mnt/news/backup/originals`): Short-term storage
      where uploaded PDFs will be moved after being split. They may need to be
-     held a few months for embargoed issues, but they're auto-purged once the
+     held a few months for embargoed issues, but they're auto-removed once the
      issue has been put into a batch.
    - `PDF_PAGE_REVIEW_PATH` (`/mnt/news/page-review`): Issues which came from
      born-digital SFTP uploads and are ready for manual page reordering - this

--- a/hugo/content/setup/services.md
+++ b/hugo/content/setup/services.md
@@ -134,9 +134,9 @@ so it isn't typically something you would run on your own, but it's also
 harmless if you do run it manually - it won't re-run any database update
 scripts that have already run.
 
-## Purge Dead Issues
+## Clean Dead Issues
 
-`purge-dead-issues` is useful to move all "stuck" issues out of NCA and into
+`remove-dead-issues` is useful to move all "stuck" issues out of NCA and into
 the configured problem folder. The original files will be moved, and the full
 activity log stored as a text file to help identify how to fix whatever problem
 prevented curators (or NCA job runners) from processing an issue.

--- a/hugo/content/workflow/_index.md
+++ b/hugo/content/workflow/_index.md
@@ -89,6 +89,6 @@ generated, the workflow is the same regardless of the source:
 10. Once the batch can be confirmed as fully archived, a batch loader flags it
     as archived.
 11. Somebody with command-line access to NCA will run `delete-live-done-issues`
-    (or set up a cron job) to purge unneeded files from NCA that are part of
+    (or set up a cron job) to clean unneeded files from NCA that are part of
     archived batches. It only deletes files when a batch is at least four weeks
     past its archive date to ensure any final problems can be handled.

--- a/hugo/content/workflow/fixing-stuck-issues.md
+++ b/hugo/content/workflow/fixing-stuck-issues.md
@@ -14,15 +14,16 @@ one area where a developer used to have to clean up the filesystem and database
 manually. As of NCA v3.8.0, there is a tool which can handle this in a
 significantly less painful way.
 
-## Purging Dead Issues
+## Cleaning Dead Issues
 
-A normal invocation of `make` creates `bin/purge-dead-issues`. This tool's sole
-purpose is to find issues which have a failed job and can no longer move
-through NCA's workflow.
+A normal invocation of `make` creates `bin/remove-dead-issues`. This tool's
+sole purpose is to find issues which have a failed job and can no longer move
+through NCA's workflow, and remove them from NCA's database and on-disk
+workflow location.
 
 Under the hood, this command does the following:
 
-- Finds all issues that are valid candidates for purging. To be valid, an issue:
+- Finds all issues that are candidates for removal. To be removed, an issue:
   - Is in the "awaiting processing" state
   - Has at least one failed job - as in "failed", which means failed forever,
     not `failed_done`, which indicates a temporary failure which was retried.
@@ -30,7 +31,7 @@ Under the hood, this command does the following:
   - Has no jobs that are pending or in process
 - Ends all jobs that were stuck - this means failed jobs as well as any "on
   hold" jobs that had been waiting for a failed job to finish
-- Creates a new job to purge the issue. This uses the same logic as issues
+- Creates a new job to delete the issue. This uses the same logic as issues
   that are flagged as having errors and removed from NCA.
 
 Once the tool has been run, you'll have stuck issues in the configured

--- a/sftpgo/deploy.md
+++ b/sftpgo/deploy.md
@@ -24,7 +24,7 @@ SFTP Server:
   - Figure out what's necessary to use the existing sftp dirs so we aren't
     having to move files during the downtime. If it's too much trouble, though,
     moving files is still acceptable.
-- Create a test user and validate various operations. Purge said user.
+- Create a test user and validate various operations. Delete said user.
 - Firewall: allow http traffic from the NCA server at a minimum; maybe library
   IP ranges for easier SFTPGo administration if necessary?
 

--- a/src/cmd/delete-live-done-issues/main.go
+++ b/src/cmd/delete-live-done-issues/main.go
@@ -51,9 +51,9 @@ func main() {
 		b.Finalize()
 	}
 
-	err = purgeIssues()
+	err = removeIssues()
 	if err != nil {
-		logger.Fatalf("Unable to purge issue directories: %s", err)
+		logger.Fatalf("Unable to remove issue directories: %s", err)
 	}
 }
 
@@ -90,7 +90,7 @@ func warning(issues []*models.Issue) {
 	}
 }
 
-func purgeIssues() error {
+func removeIssues() error {
 	var issues, err = models.FindCompletedIssuesReadyForRemoval()
 	if err != nil {
 		return fmt.Errorf("error looking for issues in live_done batches: %w", err)

--- a/src/cmd/migrate-database/_sql/20240930112500_rename_pipeline_purge_stuck_issue.sql
+++ b/src/cmd/migrate-database/_sql/20240930112500_rename_pipeline_purge_stuck_issue.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+UPDATE pipelines SET name = 'DeleteStuckIssue' WHERE name = 'PurgeStuckIssue';
+
+-- +goose Down
+UPDATE pipelines SET name = 'PurgeStuckIssue' WHERE name = 'DeleteStuckIssue';

--- a/src/cmd/migrate-database/_sql/20240930121200_rename_action_purge_to_undo_batch.sql
+++ b/src/cmd/migrate-database/_sql/20240930121200_rename_action_purge_to_undo_batch.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+UPDATE actions SET action_type = 'undo-batch' WHERE action_type = 'purge-batch';
+
+-- +goose Down
+UPDATE actions SET action_type = 'purge-batch' WHERE action_type = 'undo-batch';

--- a/src/issuewatcher/watcher.go
+++ b/src/issuewatcher/watcher.go
@@ -147,7 +147,7 @@ func (w *Watcher) refresh() {
 	// Every week, we force a full web refresh
 	var tempdir string
 	if time.Since(w.lastFullRefresh) > time.Hour*24*7 {
-		logger.Debugf("Purging cache and reindexing all data from scratch")
+		logger.Debugf("Deleting cache and reindexing all data from scratch")
 
 		// We don't want to delete tempdir when it's a routine cleaning!  TODO: make this way less hacky
 		tempdir = w.Scanner.Tempdir

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -270,7 +270,7 @@ func QueueDeleteStuckIssue(issue *models.Issue, erroredIssueRoot string) error {
 	jobs = append(jobs, issue.BuildJob(models.JobTypeIssueAction, makeActionArgs(deleteReason)))
 	jobs = append(jobs, getJobsForRemoveErroredIssue(issue, erroredIssueRoot)...)
 
-	return models.QueueJobs(models.PNDeleteStuckIssue, fmt.Sprintf("Purging issue %s and its unfinished jobs", issue.Key()), jobs...)
+	return models.QueueJobs(models.PNDeleteStuckIssue, fmt.Sprintf("Removing issue %s and its unfinished jobs", issue.Key()), jobs...)
 }
 
 // getJobsForRemoveErroredIssue returns the list of jobs for removing the given

--- a/src/jobs/remove_errored_issue_jobs.go
+++ b/src/jobs/remove_errored_issue_jobs.go
@@ -1,7 +1,7 @@
 // remove_errored_issue_jobs.go houses the jobs responsible for taking an issue
 // out of NCA entirely. WriteActionLog could be repurposed, and maybe should be
 // moved somewhere more generic, but the takeaway here is that for the most
-// part you don't use jobs here unless you mean to purge the issue from NCA.
+// part you don't use jobs here unless you mean to delete an issue from NCA.
 
 package jobs
 

--- a/src/models/action.go
+++ b/src/models/action.go
@@ -33,7 +33,7 @@ const (
 	ActionTypeApproveBatch         ActionType = "approve-batch"
 	ActionTypeRejectBatch          ActionType = "reject-batch"
 	ActionTypeFinalizeBatch        ActionType = "finalize-batch"
-	ActionTypePurgeBatch           ActionType = "purge-batch"
+	ActionTypeUndoBatch            ActionType = "undo-batch"
 	ActionTypeAbortBatchRejection  ActionType = "abort-reject-batch"
 	ActionTypeFlagBatchQCReady     ActionType = "flag-batch-qc-ready"
 )
@@ -72,8 +72,8 @@ func (at ActionType) Describe() string {
 		return "returned the batch to QC with no changes"
 	case ActionTypeFinalizeBatch:
 		return "finalized the batch for rebuild after rejecting one or more issues"
-	case ActionTypePurgeBatch:
-		return "purged the batch, moving all issues back to NCA"
+	case ActionTypeUndoBatch:
+		return "Removed the batch, moving all issues back to NCA"
 	case ActionTypeFlagBatchQCReady:
 		return "flagged the batch as being ready for QC"
 	default:

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -22,7 +22,7 @@ const (
 	PNFinalizeIssue           PipelineName = "FinalizeIssue"
 	PNMakeBatch               PipelineName = "MakeBatch"
 	PNRemoveErroredIssue      PipelineName = "RemoveErroredIssue"
-	PNPurgeStuckIssue         PipelineName = "PurgeStuckIssue"
+	PNDeleteStuckIssue        PipelineName = "DeleteStuckIssue"
 	PNFinalizeIssueFlagging   PipelineName = "FinalizeIssueFlagging"
 	PNBatchDeletion           PipelineName = "BatchDeletion"
 	PNGoLiveProcess           PipelineName = "GoLiveProcess"

--- a/templates/batches/flag_issues_form.go.html
+++ b/templates/batches/flag_issues_form.go.html
@@ -60,8 +60,9 @@
     </p>
     <p>
       If you just want to remove the batch but leave the issues in NCA for a
-      new batch generation, select "Purge" below. This will finalize flagged
-      issues, but push all the good issues back into NCA and destroy the batch.
+      new batch generation, select "Undo" below. This will finalize flagged
+      issues, but the batch will be removed, and all good issues will simply go
+      back to NCA, ready for inclusion in a new batch.
     </p>
     <p>
       If this batch doesn't need any issues removed (i.e., it was failed by
@@ -97,20 +98,20 @@
         </div>
       </cta-modal>
 
-      {{if .Data.Batch.Can.Purge}}
       <cta-modal>
         <div slot="button" class="inline">
           {{if ne 0 .Data.RemainingIssues}}
-          <button class="btn btn-primary cta-modal-toggle">Purge</button>
+          <button class="btn btn-primary cta-modal-toggle">Undo</button>
           {{else}}
-          <button class="btn btn-disabled" disabled="disabled">Purge</button>
+          <button class="btn btn-disabled" disabled="disabled">Undo</button>
           {{end}}
         </div>
 
         <div slot="modal" style="color: black;">
-          <h2>Purge Batch?</h2>
+          <h2>Undo Batch?</h2>
           <p>
-            You are about to purge {{.Data.Batch.Name}}. The following actions will occur:
+            You are about to "undo" the creation of {{.Data.Batch.Name}}. The
+            following actions will occur:
             <ul>
               <li>
                 The {{.Data.FlaggedIssues|len}} flagged issue(s) will be
@@ -122,17 +123,16 @@
                 ready to immediately be included in a new batch.
               </li>
               <li>
-                The batch will be purged from disk and from NCA.
+                The batch will be deleted from disk and from NCA.
               </li>
             </ul>
 
             <i>This is generally not necessary unless the batch was built by mistake</i>.
           </p>
-          <button class="btn btn-primary" type="submit" name="action" value="purge">Confirm</button>
+          <button class="btn btn-primary" type="submit" name="action" value="undo">Confirm</button>
           <button class="btn btn-secondary cta-modal-toggle">Cancel</button>
         </div>
       </cta-modal>
-      {{end}}
 
       <cta-modal>
         <div slot="button" class="inline">

--- a/templates/batches/view.go.html
+++ b/templates/batches/view.go.html
@@ -45,7 +45,7 @@
       entirely.
     </p>
 
-    <a href="{{FlagIssuesURL .Data.Batch}}" class="btn btn-primary">Flag Issues / Purge Batch...</a>
+    <a href="{{FlagIssuesURL .Data.Batch}}" class="btn btn-primary">Flag Issues / Undo Batch...</a>
 
     <!-- Needs production load -->
     {{else if and .Data.Batch.ReadyForProduction .Data.Batch.Can.Load}}

--- a/test/recipes/Broken-PDFs-II.md
+++ b/test/recipes/Broken-PDFs-II.md
@@ -2,7 +2,7 @@
 
 This recipe tests what happens when an issue job fails but leaves behind jobs
 that aren't directly tied to an issue (generic jobs like syncdir). This is
-useful when testing out whether the issue purge is catching everything left
+useful when testing out whether the issue removal is catching everything left
 behind (hint: it wasn't).
 
 ## Script
@@ -35,10 +35,10 @@ workers
 # Stop workers, make another backup using the "name" variable from above
 ./manage backup 02-$name
 
-# Run the command to purge dead issues
-./bin/purge-dead-issues -c ./settings
+# Run the command to remove dead issues
+./bin/remove-dead-issues -c ./settings
 
-# Purged issue should be sn96088087/2010041901
+# Removed issue should be sn96088087/2010041901
 
 # Run workers one last time (~1 min)
 workers

--- a/test/recipes/Broken-PDFs.md
+++ b/test/recipes/Broken-PDFs.md
@@ -42,10 +42,10 @@ workers >work.log 2>&1
 # Stop workers, make another backup using the "name" variable from above
 ./manage backup 02-$name
 
-# Run the command to purge dead issues (omit "--live" in new fixed branch)
-make clean && make bin/purge-dead-issues && ./bin/purge-dead-issues -c ./settings --live
+# Run the command to remove dead issues
+make clean && make bin/remove-dead-issues && ./bin/remove-dead-issues -c ./settings
 
-# Purged issues should include:
+# Deleted issues should include:
 #
 # sn88086023/2022080401
 # 2021242619/2020090201


### PR DESCRIPTION
Closes #340 

The term "purge" is now reserved for ONI batch operations, and the incorrect use of a privilege (due to name confusion on my part) has been fixed.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>