### PR TITLE
cmd/queue-batches: sort issues before queueing

### DIFF
--- a/src/cmd/queue-batches/batch_queue.go
+++ b/src/cmd/queue-batches/batch_queue.go
@@ -35,7 +35,7 @@ func (q *batchQueue) FindReadyIssues(redo bool) {
 	} else {
 		ws = schema.WSReadyForBatching
 	}
-	var issues, err = models.Issues().InWorkflowStep(ws).BatchID(0).Fetch()
+	var issues, err = models.Issues().InWorkflowStep(ws).BatchID(0).OrderBy("marc_org_code, lccn, date").Fetch()
 	if err != nil {
 		logger.Fatalf("Error trying to find issues: %s", err)
 	}


### PR DESCRIPTION
This makes our test recipes *oh so much better*: we can actually compare two test runs and know that the batches' names will always reflect the same group of issues.

This is primarily a test fix, as `queue-batches` is less and less critical now that batches are generated primarily through the web UI.