### PR TITLE
Report errors in delete-live-done-issues

### DIFF
--- a/changelogs/2024-10-31-delete-live-done-error-reporting.md
+++ b/changelogs/2024-10-31-delete-live-done-error-reporting.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- The `delete-live-done-issues` command will now report errors if a batch
+  cannot be finalized for some reason

--- a/src/cmd/delete-live-done-issues/main.go
+++ b/src/cmd/delete-live-done-issues/main.go
@@ -48,7 +48,10 @@ func main() {
 
 	for _, b := range batches {
 		logger.Infof("Closing batch %q", b.FullName())
-		b.Finalize()
+		var err = b.Finalize()
+		if err != nil {
+			logger.Errorf("Unable to close %q: %s", b.FullName(), err)
+		}
 	}
 
 	err = removeIssues()


### PR DESCRIPTION
(Ported from defunct v6.0.0 release branch)

Reports errors if the delete-live-done-issues command fails to finalize a batch. This results in a lot of "can't delete this batch because it hasn't been waiting" messages, but that's been a source of confusion in the past (silently not doing anything).

NCA's core services are unaffected.