### PR TITLE
Feature/ensure awardee

### DIFF
--- a/changelogs/2024-11-05-ensure-awardee.md
+++ b/changelogs/2024-11-05-ensure-awardee.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Before a batch is sent to ONI, its awardee is checked for existence, and the
+  ONI Agent attempts to create it if needed. This fixes some confusion in
+  documentation (no docs telling people how to add awardees to ONI, for
+  instance), and fixes the automated batch loads from getting stuck when
+  awardees don't exist on the ONI side.

--- a/compose.yml
+++ b/compose.yml
@@ -132,6 +132,7 @@ services:
       - HOST_KEY_FILE=/etc/rsa/oni-agent
       - ONI_LOCATION=/opt/openoni/
       - BATCH_SOURCE=/mnt/batches
+      - DB_CONNECTION=openoni:openoni@tcp(oni-staging-db:3306)/openoni
     expose:
       - 22
     networks:
@@ -154,6 +155,7 @@ services:
       - HOST_KEY_FILE=/etc/rsa/oni-agent
       - ONI_LOCATION=/opt/openoni/
       - BATCH_SOURCE=/mnt/batches
+      - DB_CONNECTION=openoni:openoni@tcp(oni-prod-db:3306)/openoni
     expose:
       - 22
     networks:

--- a/docker/Dockerfile-oni
+++ b/docker/Dockerfile-oni
@@ -46,6 +46,9 @@ RUN . ./docker/_startup_lib.sh && verify_config
 # process and waits 10s to shut down the container
 RUN sed -i 's|^/startup.sh$|exec /startup.sh|' /entrypoint.sh
 
+# Uncomment this if you need Oregon's real MARC record list in order to load titles
+#RUN echo "MARC_RETRIEVAL_URLFORMAT = 'https://oregonnews.uoregon.edu/lccn/%s/marc.xml'" >> onisite/settings_local.py
+
 EXPOSE 80
 ENTRYPOINT /entrypoint.sh
 

--- a/docker/Dockerfile-oni
+++ b/docker/Dockerfile-oni
@@ -56,7 +56,7 @@ ENTRYPOINT /entrypoint.sh
 
 FROM golang:1 AS agent-build
 WORKDIR /app
-RUN git clone https://github.com/open-oni/oni-agent.git -b v1.3.0 --depth 1 .
+RUN git clone https://github.com/open-oni/oni-agent.git -b v1.4.0 --depth 1 .
 RUN make
 
 

--- a/src/cmd/agent-test/main.go
+++ b/src/cmd/agent-test/main.go
@@ -41,7 +41,7 @@ var aliases = map[string]string{
 	"lmoc":     cmdEnsureAwardee,
 }
 
-var validCmds = []string{cmdLoad, cmdPurge, cmdStatus, cmdLogs}
+var validCmds = []string{cmdLoad, cmdPurge, cmdStatus, cmdLogs, cmdEnsureAwardee}
 
 func setUsage(c *cli.CLI) {
 	c.AppendUsage(`Allows testing ONI Agents as well as running common commands against staging and production`)

--- a/src/cmd/agent-test/main.go
+++ b/src/cmd/agent-test/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/uoregon-libraries/newspaper-curation-app/src/cli"
 	"github.com/uoregon-libraries/newspaper-curation-app/src/internal/openoni"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 )
 
 type _opts struct {
@@ -19,21 +21,24 @@ type _opts struct {
 var opts _opts
 
 const (
-	cmdLoad   = "load-batch"
-	cmdPurge  = "purge-batch"
-	cmdStatus = "job-status"
-	cmdLogs   = "job-logs"
+	cmdLoad          = "load-batch"
+	cmdPurge         = "purge-batch"
+	cmdStatus        = "job-status"
+	cmdLogs          = "job-logs"
+	cmdEnsureAwardee = "ensure-awardee"
 )
 
 var aliases = map[string]string{
-	"load":  cmdLoad,
-	"bl":    cmdLoad,
-	"purge": cmdPurge,
-	"bp":    cmdPurge,
-	"stat":  cmdStatus,
-	"js":    cmdStatus,
-	"logs":  cmdLogs,
-	"jl":    cmdLogs,
+	"load":     cmdLoad,
+	"bl":       cmdLoad,
+	"purge":    cmdPurge,
+	"bp":       cmdPurge,
+	"stat":     cmdStatus,
+	"js":       cmdStatus,
+	"logs":     cmdLogs,
+	"jl":       cmdLogs,
+	"load-moc": cmdEnsureAwardee,
+	"lmoc":     cmdEnsureAwardee,
 }
 
 var validCmds = []string{cmdLoad, cmdPurge, cmdStatus, cmdLogs}
@@ -114,6 +119,18 @@ func main() {
 		for _, line := range logs {
 			fmt.Println(line)
 		}
+
+	case cmdEnsureAwardee:
+		if len(args) != 2 {
+			log.Fatalf("Invalid request: you must specify an org code and awardee's name")
+		}
+
+		var m = &models.MOC{Code: args[0], Name: args[1]}
+		var message, err = rpc.EnsureAwardee(m)
+		if err != nil {
+			log.Fatalf("Couldn't check/create awardee: %s", err)
+		}
+		fmt.Println("Success:", message)
 
 	default:
 		log.Fatalf("Command %q not handled in main", command)

--- a/src/cmd/agent-test/main.go
+++ b/src/cmd/agent-test/main.go
@@ -43,9 +43,26 @@ var aliases = map[string]string{
 
 var validCmds = []string{cmdLoad, cmdPurge, cmdStatus, cmdLogs}
 
+func setUsage(c *cli.CLI) {
+	c.AppendUsage(`Allows testing ONI Agents as well as running common commands against staging and production`)
+	var aliasmap = make(map[string][]string)
+	for alias, cmd := range aliases {
+		aliasmap[cmd] = append(aliasmap[cmd], alias)
+	}
+
+	var all []string
+	for _, cmd := range validCmds {
+		var aList = aliasmap[cmd]
+		sort.Strings(aList)
+		var s = strings.Join(aList, " / ")
+		all = append(all, fmt.Sprintf("%s (%s)", cmd, s))
+	}
+	c.AppendUsage("Valid commands and aliases: " + strings.Join(all, ", "))
+}
+
 func getOpts() (rpc *openoni.RPC, command string, args []string) {
 	var c = cli.New(&opts)
-	c.AppendUsage(`Allows testing ONI Agents as well as running common commands against staging and production`)
+	setUsage(c)
 	var conf = c.GetConf()
 
 	var connection string
@@ -55,7 +72,7 @@ func getOpts() (rpc *openoni.RPC, command string, args []string) {
 	case "production", "prod", "p":
 		connection = conf.ProductionAgentConnection
 	default:
-		log.Fatalf("Invalid environment %q", opts.Environment)
+		c.UsageFail("Invalid environment %q", opts.Environment)
 	}
 
 	var err error
@@ -65,7 +82,7 @@ func getOpts() (rpc *openoni.RPC, command string, args []string) {
 	}
 
 	if len(c.Args) == 0 {
-		log.Fatalf("You must specify a valid command")
+		c.UsageFail("You must specify a command")
 	}
 	command, args = c.Args[0], c.Args[1:]
 	if aliases[command] != "" {
@@ -78,7 +95,7 @@ func getOpts() (rpc *openoni.RPC, command string, args []string) {
 		}
 	}
 	if !valid {
-		log.Fatalf("Invalid command. You must choose one of: %s", strings.Join(validCmds, ", "))
+		c.UsageFail("%q is not a valid command", command)
 	}
 
 	var version string
@@ -96,6 +113,7 @@ func main() {
 	if len(args) == 0 {
 		args = []string{""}
 	}
+
 	switch command {
 	case cmdLoad:
 		doBatch(rpc, rpc.LoadBatch, args[0], false)

--- a/src/internal/openoni/api.go
+++ b/src/internal/openoni/api.go
@@ -87,7 +87,7 @@ func (r *RPC) do(params ...string) (result gjson.Result, err error) {
 	case "success":
 		return result, nil
 	case "error":
-		return result, fmt.Errorf("calling %q: %s", strings.Join(params, " "), result.Get("message").String())
+		return result, fmt.Errorf("calling %q: %s (%s)", strings.Join(params, " "), result.Get("message").String(), result.Get("error").String())
 	default:
 		return result, fmt.Errorf("parsing status for call to %q: invalid value %q", strings.Join(params, " "), status)
 	}

--- a/src/internal/openoni/api.go
+++ b/src/internal/openoni/api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -120,6 +121,17 @@ func (r *RPC) GetVersion() (version string, err error) {
 	}
 
 	return result.Get("version").String(), nil
+}
+
+// EnsureAwardee tells the agent to verify or create the given MOC in ONI
+func (r *RPC) EnsureAwardee(moc *models.MOC) (message string, err error) {
+	var result gjson.Result
+	result, err = r.do("ensure-awardee", moc.Code, moc.Name)
+	if err != nil {
+		return "", fmt.Errorf("calling ensure-awardee: %w", err)
+	}
+
+	return result.Get("message").String(), nil
 }
 
 // JobStatus is the "controlled" version of an ONI Agent's job-status response

--- a/src/internal/openoni/api.go
+++ b/src/internal/openoni/api.go
@@ -68,6 +68,13 @@ func (r *RPC) do(params ...string) (result gjson.Result, err error) {
 		r.call = r.defaultCall
 	}
 
+	// Quote all parameters the cheap and hacky way. This quotes the command as
+	// well, but that's a non-issue, as the ONI Agent processes everything,
+	// including the command, the same way (unquoting).
+	for i := range params {
+		params[i] = fmt.Sprintf("%q", params[i])
+	}
+
 	var data []byte
 	data, err = r.call(params)
 	if err != nil {

--- a/src/internal/openoni/api_test.go
+++ b/src/internal/openoni/api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/models"
 )
 
 func TestNew(t *testing.T) {
@@ -160,6 +161,17 @@ func TestPurgeBatch(t *testing.T) {
 				t.Fatalf("PurgeBatch(%q) (json %q): expected job id %d, got %d", tc.batch, tc.json, tc.jobID, id)
 			}
 		})
+	}
+}
+
+func TestEnsureAwardee(t *testing.T) {
+	var r = getRPC(t, "EnsureAwardee", []string{"ensure-awardee", "code", "name"}, []byte(`{"status": "success", "message": "test"}`))
+	var message, err = r.EnsureAwardee(&models.MOC{Code: "code", Name: "name"})
+	if message != "test" {
+		t.Errorf(`EnsureAwardee should return the message "test". Got %q`, message)
+	}
+	if err != nil {
+		t.Errorf("EnsureAwardee should not have an error, got %s", err)
 	}
 }
 

--- a/src/internal/openoni/api_test.go
+++ b/src/internal/openoni/api_test.go
@@ -2,6 +2,7 @@ package openoni
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -41,6 +42,11 @@ func getRPC(t *testing.T, name string, expectedParams []string, jsonOut []byte) 
 		t.Fatalf("Unable to provision new RPC: %s", err)
 	}
 	r.call = func(params []string) (data []byte, err error) {
+		// Quote expected params before comparison
+		for i := range expectedParams {
+			expectedParams[i] = fmt.Sprintf("%q", expectedParams[i])
+		}
+
 		if len(expectedParams) > 0 {
 			var diff = cmp.Diff(expectedParams, params)
 			if diff != "" {

--- a/src/jobs/api_jobs.go
+++ b/src/jobs/api_jobs.go
@@ -48,8 +48,6 @@ func (j *BatchJob) queueAgentJob(name string, fn batchJobFunc) ProcessResponse {
 	// need to be scrutinized
 	j.DBBatch.ONIAgentJobID = jobid
 
-	// TODO: Insert job into the pipeline to wait for the ONI side to finish
-
 	// It's pretty critical that we save the batch data and queue a "wait for
 	// ONI" job since the ONI job was successfully created
 	err = j.runCritical(func() error {


### PR DESCRIPTION
Closes #218 

Sends command to ONI Agent to verify or else create awardees when necessary. If an org code in NCA doesn't have a name, however, an awardee cannot be automatically generated, so legacy data may still require manual awardee creation.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>
