### PR TITLE
Feature/better oni agent

### DIFF
--- a/docker/Dockerfile-oni
+++ b/docker/Dockerfile-oni
@@ -59,7 +59,7 @@ ENTRYPOINT /entrypoint.sh
 
 FROM golang:1 AS agent-build
 WORKDIR /app
-RUN git clone https://github.com/open-oni/oni-agent.git -b v1.4.0 --depth 1 .
+RUN git clone https://github.com/open-oni/oni-agent.git -b v1.5.0 --depth 1 .
 RUN make
 
 

--- a/hugo/content/setup/installation.md
+++ b/hugo/content/setup/installation.md
@@ -24,10 +24,10 @@ Manual installation has several prerequisites:
   [RAIS](https://github.com/uoregon-libraries/rais-image-server))
 - Apache/nginx for authentication as well as proxying to NCA and the IIIF server
 - Two running [Open ONI][oni] applications: staging and production.
-- An [ONI Agent][agent] must be set up for each ONI instance in order to
-  automate some of the functionality from NCA to ONI. The NCA server needs to
-  be able to connect to the ONI Agent, but the agent's ports should not be open
-  to any other traffic.
+- An [ONI Agent][agent] (at least v1.5.0) must be set up for each ONI instance
+  in order to automate some of the functionality from NCA to ONI. The NCA
+  server needs to be able to connect to the ONI Agent, but the agent's ports
+  should not be open to any other traffic.
   - In our setup, we have an internal-network-only port for the agents, and
     they run using systemd so that they start on reboot and we can specify
     their settings directly in the systemd unit's environment. The ONI Agent


### PR DESCRIPTION
Dev- and doc-only changes. In docker, pins to the latest ONI Agent. Documentation explicitly states the required version of ONI Agent.

No production impact.