### PR TITLE
Feature/upload marc titles

### DIFF
--- a/changelogs/2024-12-12-upload-marc.md
+++ b/changelogs/2024-12-12-upload-marc.md
@@ -1,0 +1,33 @@
+### Fixed
+
+- Internal refactors which affect the "public" APIs. But don't use these. I
+  just haven't gotten around to moving everything to a proper "internal"
+  subdirectory.
+
+### Added
+
+- NCA's "Titles" view now has a link to upload MARC XML. If you do an upload,
+  two things happen:
+  - NCA will create or update any record with a matching LCCN with the basic
+    MARC data it cares about: LCCN, name, location, and some internal fields
+    like the fact that it considers the title's LCCN to be validated.
+  - The ONI agents (staging and production) will be given a command to load the
+    MARC record into ONI. This will mean *no more batch failures* due to a
+    missing title.
+- You can use the ONI Agent test binary to load titles into ONI if you need to
+  do some testing. Otherwise just use NCA so all the pieces stay consistent.
+
+### Changed
+
+- A lot of the integrated testing (automated "manual" testing in the `test`
+  directory) has been simplified and improved. You no longer need to bring your
+  own seed SQL if you use our test repository. You can create MARC records that
+  NCA will auto-load for your own test data. If you test this way, re-read the
+  README in its entirety!
+
+### Migration
+
+- If you had a custom nca-seed-data.sql, you should rename it, and you'll have
+  to abandon it or manually load it when needed. This part of the integration
+  suite is no longer done for you to make it easier for a typical developer to
+  just dive into the tests.

--- a/docker/Dockerfile-oni
+++ b/docker/Dockerfile-oni
@@ -59,7 +59,7 @@ ENTRYPOINT /entrypoint.sh
 
 FROM golang:1 AS agent-build
 WORKDIR /app
-RUN git clone https://github.com/open-oni/oni-agent.git -b v1.5.1 --depth 1 .
+RUN git clone https://github.com/open-oni/oni-agent.git -b v1.6.0 --depth 1 .
 RUN make
 
 

--- a/docker/mysql/nca-seed-data.sql
+++ b/docker/mysql/nca-seed-data.sql
@@ -1,0 +1,3 @@
+INSERT INTO `mocs` (`code`, `name`) VALUES
+    ('oru','University of Oregon Libraries; Eugene, OR'),
+    ('hoodriverlibrary','Hood River County Library District; Hood River, OR');

--- a/hugo/content/setup/creating-publishers.md
+++ b/hugo/content/setup/creating-publishers.md
@@ -7,10 +7,7 @@ description: Setting up a new NCA toolsuite
 Creating a publisher in NCA, at least for UO, requires several manual processes
 take place:
 
-- Add a title to NCA with sftp credential information.
-- If necessary, import the title's MARC record to your ONI site (for example,
-  oregonnews.uoregon.edu).
-  - See [Adding Titles](/workflow/adding-titles) for details
-- Set up a user for sftp access
-  - We use NCA's integrated SFTPGo setup for this. See
-    [SFTPGo Integration](/setup/sftpgo-integration).
+- Upload a MARC record for the title, and then edit them to provide SFTP
+  credentials.
+- Set up a user for sftp access if you aren't using the SFTPGo integration (but
+  you really should, it's way easier)

--- a/hugo/content/workflow/adding-titles.md
+++ b/hugo/content/workflow/adding-titles.md
@@ -16,13 +16,12 @@ for titles not indexed elsewhere. Here's our process:
     this and knows the right people to contact
 - Generate MARC XML for the title(s)
   - [MarcEdit](https://marcedit.reeset.net) is a popular choice for this
-- Ingest the XML into ONI:
-  - Put the MARC XML files into a filesystem location ONI can read
-  - Use the ONI administration command `load_titles` to ingest, e.g.:
-    `./manage.py load_titles /path/to/marcxml/`
-- Point NCA to your local ONI server instead of, or in addition to, Library of
-  Congress. This can be done by modifyting the NCA settings `MARC_LOCATION_1`
-  and/or `MARC_LOCATION_2`. e.g.:
+- Upload the XML into NCA. This creates records in staging and production ONI
+  instances as well as a record "stub" in NCA.
+- If you already have titles in ONI, and don't want to upload their MARC
+  records, you can also point NCA to your local ONI server instead of, or in
+  addition to, Library of Congress. This can be done by modifyting the NCA
+  settings `MARC_LOCATION_1` and/or `MARC_LOCATION_2`. e.g.:
   ```
   MARC_LOCATION_1="https://oregonnews.uoregon.edu/lccn/{{lccn}}/marc.xml"
   MARC_LOCATION_2="https://chroniclingamerica.loc.gov/lccn/{{lccn}}/marc.xml"

--- a/internal/openoni/api.go
+++ b/internal/openoni/api.go
@@ -2,6 +2,7 @@
 package openoni
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"sort"
@@ -14,10 +15,13 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// This is dumb but lets us build and pass around string slices in a clearer way
+type slist []string
+
 // RPC manages the ssh connections to a single ONI Agent
 type RPC struct {
 	connection string
-	call       func([]string) ([]byte, error)
+	call       func(slist, []byte) ([]byte, error)
 }
 
 // New parses the connection string into a server and port. Its format must be
@@ -36,7 +40,7 @@ func New(connection string) (*RPC, error) {
 	return &RPC{connection: connection}, nil
 }
 
-func (r *RPC) defaultCall(params []string) (data []byte, err error) {
+func (r *RPC) defaultCall(params slist, payload []byte) (data []byte, err error) {
 	var cfg = &ssh.ClientConfig{
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         time.Second * 10,
@@ -55,15 +59,26 @@ func (r *RPC) defaultCall(params []string) (data []byte, err error) {
 	}
 
 	var cmd = strings.Join(params, " ")
-	data, err = s.Output(cmd)
-	if err != nil {
-		return data, fmt.Errorf("sending command %q to server: %w", cmd, err)
+
+	// If we have a payload, set the session's Stdin to a readable buffer
+	if payload != nil {
+		// We write the payload to an empty buffer rather than using it directly in
+		// [bytes.NewBuffer], which takes control of the underlying data and
+		// documents that the caller should *never use it again*.
+		var stdin = new(bytes.Buffer)
+		// A [bytes.Buffer] will never fail to write
+		_, _ = stdin.Write(payload)
+		s.Stdin = stdin
 	}
 
-	return data, nil
+	data, err = s.Output(cmd)
+	if err != nil {
+		err = fmt.Errorf("sending %q (no payload) to ONI Agent: %w", cmd, err)
+	}
+	return data, err
 }
 
-func (r *RPC) do(params ...string) (result gjson.Result, err error) {
+func (r *RPC) do(params slist, payload []byte) (result gjson.Result, err error) {
 	if r.call == nil {
 		r.call = r.defaultCall
 	}
@@ -76,7 +91,7 @@ func (r *RPC) do(params ...string) (result gjson.Result, err error) {
 	}
 
 	var data []byte
-	data, err = r.call(params)
+	data, err = r.call(params, payload)
 	if err != nil {
 		return result, err
 	}
@@ -98,7 +113,7 @@ func (r *RPC) do(params ...string) (result gjson.Result, err error) {
 // job's status for completion.
 func (r *RPC) LoadBatch(name string) (id int64, err error) {
 	var result gjson.Result
-	result, err = r.do("load-batch", name)
+	result, err = r.do(slist{"load-batch", name}, nil)
 	if err != nil {
 		return 0, fmt.Errorf("requesting batch load: %w", err)
 	}
@@ -111,7 +126,7 @@ func (r *RPC) LoadBatch(name string) (id int64, err error) {
 // job's status for completion.
 func (r *RPC) PurgeBatch(name string) (id int64, err error) {
 	var result gjson.Result
-	result, err = r.do("purge-batch", name)
+	result, err = r.do(slist{"purge-batch", name}, nil)
 	if err != nil {
 		return 0, fmt.Errorf("requesting batch purge: %w", err)
 	}
@@ -122,7 +137,7 @@ func (r *RPC) PurgeBatch(name string) (id int64, err error) {
 // GetVersion returns the version string of the ONI Agent
 func (r *RPC) GetVersion() (version string, err error) {
 	var result gjson.Result
-	result, err = r.do("version")
+	result, err = r.do(slist{"version"}, nil)
 	if err != nil {
 		return "", fmt.Errorf("requesting ONI Agent version: %w", err)
 	}
@@ -133,9 +148,21 @@ func (r *RPC) GetVersion() (version string, err error) {
 // EnsureAwardee tells the agent to verify or create the given MOC in ONI
 func (r *RPC) EnsureAwardee(moc *models.MOC) (message string, err error) {
 	var result gjson.Result
-	result, err = r.do("ensure-awardee", moc.Code, moc.Name)
+	result, err = r.do(slist{"ensure-awardee", moc.Code, moc.Name}, nil)
 	if err != nil {
 		return "", fmt.Errorf("calling ensure-awardee: %w", err)
+	}
+
+	return result.Get("message").String(), nil
+}
+
+// LoadTitle sends data to an ONI Agent's "load-title" command. data needs to
+// be valid MARC XML.
+func (r *RPC) LoadTitle(data []byte) (message string, err error) {
+	var result gjson.Result
+	result, err = r.do(slist{"load-title"}, data)
+	if err != nil {
+		return "", fmt.Errorf("calling load-title: %w", err)
 	}
 
 	return result.Get("message").String(), nil
@@ -168,7 +195,7 @@ func (js JobStatus) valid() bool {
 // GetJobStatus returns the status response from ONI Agent for the given job id
 func (r *RPC) GetJobStatus(id int64) (js JobStatus, err error) {
 	var result gjson.Result
-	result, err = r.do("job-status", strconv.FormatInt(id, 10))
+	result, err = r.do(slist{"job-status", strconv.FormatInt(id, 10)}, nil)
 	if err == nil {
 		result = result.Get("job")
 		if !result.Exists() {
@@ -190,7 +217,7 @@ func (r *RPC) GetJobStatus(id int64) (js JobStatus, err error) {
 // job's output streams
 func (r *RPC) GetJobLogs(id int64) (logs []string, err error) {
 	var result gjson.Result
-	result, err = r.do("job-logs", strconv.FormatInt(id, 10))
+	result, err = r.do(slist{"job-logs", strconv.FormatInt(id, 10)}, nil)
 	if err == nil {
 		result = result.Get("job")
 		if !result.Exists() {

--- a/internal/openoni/api.go
+++ b/internal/openoni/api.go
@@ -102,7 +102,7 @@ func (r *RPC) do(params slist, payload []byte) (result gjson.Result, err error) 
 	case "success":
 		return result, nil
 	case "error":
-		return result, fmt.Errorf("calling %q: %s (%s)", strings.Join(params, " "), result.Get("message").String(), result.Get("error").String())
+		return result, fmt.Errorf("agent response: %s (%s)", result.Get("message").String(), result.Get("error").String())
 	default:
 		return result, fmt.Errorf("parsing status for call to %q: invalid value %q", strings.Join(params, " "), status)
 	}

--- a/internal/openoni/api.go
+++ b/internal/openoni/api.go
@@ -66,8 +66,7 @@ func (r *RPC) defaultCall(params slist, payload []byte) (data []byte, err error)
 		// [bytes.NewBuffer], which takes control of the underlying data and
 		// documents that the caller should *never use it again*.
 		var stdin = new(bytes.Buffer)
-		// A [bytes.Buffer] will never fail to write
-		_, _ = stdin.Write(payload)
+		_, _ = stdin.WriteString(string(payload) + "\n\nEND\n")
 		s.Stdin = stdin
 	}
 

--- a/scripts/localdev.sh
+++ b/scripts/localdev.sh
@@ -82,7 +82,13 @@ migrate() {
 }
 
 load_seed_data() {
-  mysql -unca -pnca -Dnca -h127.0.0.1 < ./docker/mysql/nca-seed-data.sql
+  mysql -unca -pnca -Dnca -h127.0.0.1 -e "INSERT INTO mocs (code, name) VALUES
+    ('oru','University of Oregon Libraries; Eugene, OR'),
+    ('hoodriverlibrary','Hood River County Library District; Hood River, OR');"
+  pushd .
+  cd ./test
+  go run load-marc.go -c ../settings
+  popd
 }
 
 create_test_users() {

--- a/src/cmd/server/internal/audithandler/form.go
+++ b/src/cmd/server/internal/audithandler/form.go
@@ -25,7 +25,7 @@ type form struct {
 
 var actionLookup = map[string][]models.AuditAction{
 	"Uploads":        {models.AuditActionQueue},
-	"Titles":         {models.AuditActionSaveTitle, models.AuditActionValidateTitle},
+	"Titles":         {models.AuditActionSaveTitle, models.AuditActionValidateTitle, models.AuditActionUploadMARC},
 	"MARC Org Codes": {models.AuditActionCreateMoc, models.AuditActionUpdateMoc, models.AuditActionDeleteMoc},
 	"Users":          {models.AuditActionSaveUser, models.AuditActionDeactivateUser},
 	"Issue Workflow": {

--- a/src/cmd/server/internal/titlehandler/handlers.go
+++ b/src/cmd/server/internal/titlehandler/handlers.go
@@ -494,20 +494,17 @@ func processMARCUploadHandler(w http.ResponseWriter, req *http.Request) {
 
 		if t.ID == 0 {
 			result.New = true
-			t = &models.Title{
-				Name:         m.Title(),
-				LCCN:         m.LCCN(),
-				MARCTitle:    m.Title(),
-				MARCLocation: m.Location(),
-				ValidLCCN:    true,
-				LangCode3:    m.Language(),
-			}
-		} else {
-			t.ValidLCCN = true
-			t.MARCTitle = m.Title()
-			t.MARCLocation = m.Location()
-			t.LangCode3 = m.Language()
 		}
+
+		// [models.FindTitleByLCCN] returns an immediately-usable empty title if
+		// nothing is found, so this is always safe: we're either updating an
+		// existing title or adding a new one.
+		t.LCCN = m.LCCN()
+		t.Name = m.Title() + " (" + m.Location() + ")"
+		t.ValidLCCN = true
+		t.MARCTitle = m.Title()
+		t.MARCLocation = m.Location()
+		t.LangCode3 = m.Language()
 
 		err = t.Save()
 		if err != nil {

--- a/src/cmd/server/internal/titlehandler/handlers.go
+++ b/src/cmd/server/internal/titlehandler/handlers.go
@@ -417,9 +417,8 @@ func loadTitle(fh *multipart.FileHeader) (m *marc.MARC, message string) {
 	}
 
 	// Do a quick sanity check that the data is valid MARC
-	var buf = new(bytes.Buffer)
-	_, _ = buf.Write(upload)
-	m, err = marc.ParseXML(f)
+	var buf = bytes.NewReader(upload)
+	m, err = marc.ParseXML(buf)
 	if err != nil {
 		logger.Errorf("Invalid XML uploaded in file %q: %s", fh.Filename, err)
 		return nil, "File is invalid or doesn't contain MARC XML"

--- a/src/jobs/build_mets_xml.go
+++ b/src/jobs/build_mets_xml.go
@@ -28,7 +28,7 @@ func (job *BuildMETS) Process(c *config.Config) ProcessResponse {
 	job.outputXMLPath = job.DBIssue.METSFile()
 
 	var err error
-	job.Title, err = models.FindTitle("lccn = ?", job.DBIssue.LCCN)
+	job.Title, err = models.FindTitleByLCCN(job.DBIssue.LCCN)
 	if err != nil {
 		job.Logger.Errorf("Unable to look up title for issue id %d (LCCN %q): %s", job.DBIssue.ID, job.DBIssue.LCCN, err)
 		return PRFailure

--- a/src/models/audit_log.go
+++ b/src/models/audit_log.go
@@ -36,6 +36,7 @@ const (
 	AuditActionAutosave
 	AuditActionSaveDraft
 	AuditActionSaveQueue
+	AuditActionUploadMARC
 
 	AuditActionOverflow
 )
@@ -60,6 +61,7 @@ var dbAuditActions = map[AuditAction]string{
 	AuditActionAutosave:         "autosave",
 	AuditActionSaveDraft:        "savedraft",
 	AuditActionSaveQueue:        "savequeue",
+	AuditActionUploadMARC:       "upload-marc",
 }
 
 // String returns the human-readable value for an action
@@ -87,6 +89,7 @@ var auditActionLookup = map[string]AuditAction{
 	"autosave":           AuditActionAutosave,
 	"savedraft":          AuditActionSaveDraft,
 	"savequeue":          AuditActionSaveQueue,
+	"upload-marc":        AuditActionUploadMARC,
 }
 
 // AuditActionFromString returns the action int for the given string, if the

--- a/src/models/issue.go
+++ b/src/models/issue.go
@@ -308,7 +308,7 @@ func FindIssue(id int64) (*Issue, error) {
 		return nil, op.Err()
 	}
 	var err error
-	i.Title, err = FindTitle("lccn = ?", i.LCCN)
+	i.Title, err = FindTitleByLCCN(i.LCCN)
 	if err != nil {
 		return nil, err
 	}

--- a/src/models/title.go
+++ b/src/models/title.go
@@ -26,8 +26,8 @@ type Title struct {
 	LangCode3     string
 }
 
-// FindTitle searches the database for a single title
-func FindTitle(where string, args ...any) (*Title, error) {
+// findTitle searches the database for a single title
+func findTitle(where string, args ...any) (*Title, error) {
 	var op = dbi.DB.Operation()
 	op.Dbg = dbi.Debug
 	var t = &Title{}
@@ -35,9 +35,14 @@ func FindTitle(where string, args ...any) (*Title, error) {
 	return t, op.Err()
 }
 
-// FindTitleByID wraps FindTitle to simplify basic finding
+// FindTitleByID gets a title with the given ID
 func FindTitleByID(id int64) (*Title, error) {
-	return FindTitle("id = ?", id)
+	return findTitle("id = ?", id)
+}
+
+// FindTitleByLCCN gets a title with the given LCCN
+func FindTitleByLCCN(lccn string) (*Title, error) {
+	return findTitle("lccn = ?", lccn)
 }
 
 // TitleList holds a full list of database titles for quick scan operations on

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -168,3 +168,8 @@ label.btn:has(+input:focus-visible) {
 	border-color: var(--bs-btn-hover-border-color);
 	box-shadow: var(--bs-btn-focus-box-shadow);
 }
+
+.marc-new-warning {
+  color: var(--bs-warning-text-emphasis);
+  font-size: 0.75em;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -168,9 +168,3 @@ label.btn:has(+input:focus-visible) {
 	border-color: var(--bs-btn-hover-border-color);
 	box-shadow: var(--bs-btn-focus-box-shadow);
 }
-
-.marc-new-warning {
-  color: var(--bs-warning-text-emphasis);
-  font-size: 0.75em;
-  margin-top: 0.25em;
-}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,7 +4,13 @@ body {
   padding-bottom: 70px;
 }
 
-a:focus, button:focus {
+a:focus, button:focus, label.btn:has(+ input:focus) {
+  outline: 1px solid var(--bs-primary-text-emphasis);
+  box-shadow: 0px 0px 0px 2px var(--bs-body-color);
+  transition: none;
+}
+
+a:focus, button:focus, label.btn:has(+ input:focus) {
   outline: 1px solid var(--bs-primary-text-emphasis);
   box-shadow: 0px 0px 0px 2px var(--bs-body-color);
   transition: none;
@@ -146,7 +152,19 @@ button.copy {
 /* Simple outline button style to replicate the old "default" button */
 .btn-outline {
   --bs-btn-border-color: oklch(15% 0 0);
+  --bs-btn-hover-border-color: oklch(15% 0 0);
+  --bs-btn-hover-bg: oklch(28% 0.15 265);
+  --bs-btn-color: var(--bs-body-color);
+  --bs-btn-hover-color: oklch(95% 0 0);
 }
-[data-bs-theme=dark] .btn-outline {
+[data-bs-theme=dark] .btn-outline, label.btn-outline:has(+ input:focus) {
   --bs-btn-border-color: oklch(85% 0 0);
+  --bs-btn-hover-border-color: oklch(85% 0 0);
+  --bs-btn-hover-bg: oklch(28% 0.15 265);
+}
+label.btn:has(+input:focus-visible) {
+	color: var(--bs-btn-hover-color);
+	background-color: var(--bs-btn-hover-bg);
+	border-color: var(--bs-btn-hover-border-color);
+	box-shadow: var(--bs-btn-focus-box-shadow);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -172,4 +172,5 @@ label.btn:has(+input:focus-visible) {
 .marc-new-warning {
   color: var(--bs-warning-text-emphasis);
   font-size: 0.75em;
+  margin-top: 0.25em;
 }

--- a/static/css/upload.css
+++ b/static/css/upload.css
@@ -17,3 +17,9 @@
     border: 1px solid var(--bs-body-color);
   }
 }
+
+.marc-new-warning {
+  color: var(--bs-warning-text-emphasis);
+  font-size: 0.75em;
+  margin-top: 0.25em;
+}

--- a/static/css/upload.css
+++ b/static/css/upload.css
@@ -1,0 +1,19 @@
+#marc-upload-form {
+  ol {
+    padding-left: 0;
+  }
+
+  p {
+    line-height: 32px;
+    padding-left: 10px;
+  }
+
+  li, div > p {
+    background: var(--bs-body-bg);
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    list-style-type: none;
+    border: 1px solid var(--bs-body-color);
+  }
+}

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -1,0 +1,44 @@
+window.addEventListener('load', function () {
+  const input = document.getElementById('marc-uploader');
+  const preview = document.getElementById('preview');
+
+  input.addEventListener('change', updateFileList);
+
+  function updateFileList() {
+    while(preview.firstChild) {
+      preview.removeChild(preview.firstChild);
+    }
+
+    const curFiles = input.files;
+    if(curFiles.length === 0) {
+      const para = document.createElement('p');
+      para.textContent = 'No files currently selected for upload';
+      preview.appendChild(para);
+      return;
+    }
+
+    const list = document.createElement('ol');
+    preview.appendChild(list);
+
+    for(const file of curFiles) {
+      const listItem = document.createElement('li');
+      const para = document.createElement('p');
+
+      para.textContent = `File name "${file.name}", file size ${fileSizeHuman(file.size)}.`;
+      listItem.appendChild(para);
+      list.appendChild(listItem);
+    }
+  }
+
+  function fileSizeHuman(number) {
+    if (number < 1024) {
+      return number + 'bytes';
+    }
+    if (number > 1024 && number < 1048576) {
+      return (number/1024).toFixed(1) + 'KB';
+    }
+    if (number > 1048576) {
+      return (number/1048576).toFixed(1) + 'MB';
+    }
+  }
+});

--- a/templates/layout.go.html
+++ b/templates/layout.go.html
@@ -23,7 +23,7 @@
   </head>
 
   <body>
-    <a class="skiplink sr-only sr-only-focusable" href="#maincontent">
+    <a class="skiplink" href="#maincontent">
       Skip to main content
     </a>
 

--- a/templates/layout.go.html
+++ b/templates/layout.go.html
@@ -19,6 +19,7 @@
     {{IncludeJS "disclosureButton"}}
     {{IncludeJS "copy-clipboard"}}
     {{RawJS "cta-modal/cta-modal.js"}}
+    {{IncludeCSS "upload"}}
   </head>
 
   <body>

--- a/templates/titles/form.go.html
+++ b/templates/titles/form.go.html
@@ -23,7 +23,6 @@
       <div id="name-help" class="form-text">Enter the name as required by chronam: "title. (city, Or.)"</div>
     </div>
   </div>
-  </table>
 
   <div class="row mb-3">
     <label class="col-sm-2 offset-sm-2 col-form-label" for="lccn">LCCN</label>

--- a/templates/titles/list.go.html
+++ b/templates/titles/list.go.html
@@ -2,9 +2,8 @@
 
 {{if .User.PermittedTo ModifyTitles}}
 <ul>
-  <li>
-    <a href="{{TitlesHomeURL}}/new">Create new title</a>
-  </li>
+  <li><a href="{{TitlesHomeURL}}/new">Create new title</a></li>
+  <li><a href="{{TitlesUploadMARCURL}}">Upload a MARC record</a></li>
 </ul>
 {{end}}
 

--- a/templates/titles/upload-marc.go.html
+++ b/templates/titles/upload-marc.go.html
@@ -6,6 +6,23 @@
   [1]: <https://github.com/mdn/learning-area/blob/main/html/forms/file-examples/file-example.html>
 -->
 
+<p>
+  <h2>Notes:</h2>
+  <ul>
+    <li>
+      If you upload a lot of files at once, it will take a while for this page
+      to respond. It is recommended you upload no more than 5 files at a time.
+    </li><li>
+      The files must contain only <em>one</em> MARC record! Multi-record files
+      are not currently supported.
+    </li>
+  </ul>
+</p>
+
+<hr />
+
+<h2>Upload</h2>
+
 <form id="marc-upload-form" method="post" action="{{TitlesUploadMARCURL}}" enctype="multipart/form-data">
   <div class="row mb-3">
     <div class="col-sm-2">

--- a/templates/titles/upload-marc.go.html
+++ b/templates/titles/upload-marc.go.html
@@ -1,0 +1,31 @@
+{{block "content" .}}
+
+<!--
+  This page is partly based on MDN's [File Example][1] HTML/JS/CSS.
+
+  [1]: <https://github.com/mdn/learning-area/blob/main/html/forms/file-examples/file-example.html>
+-->
+
+<form id="marc-upload-form" method="post" action="{{TitlesUploadMARCURL}}" enctype="multipart/form-data">
+  <div class="row mb-3">
+    <div class="col-sm-2">
+      <label class="btn btn-outline" for="marc-uploader">Choose File(s)...</label>
+      <input type="file" class="visually-hidden" id="marc-uploader" name="marc" accept=".xml, .mrk" multiple />
+    </div>
+    <div class="col-sm-2">
+      <button class="btn btn-primary" type="Submit">Upload</button>
+    </div>
+    <div id="preview" class="col-sm-8">
+      <p>No files currently selected for upload</p>
+    </div>
+  </div>
+</form>
+
+</body>
+</html>
+
+{{end}}
+
+{{block "extrajs" .}}
+{{IncludeJS "upload"}}
+{{end}}

--- a/templates/titles/upload-marc.go.html
+++ b/templates/titles/upload-marc.go.html
@@ -21,9 +21,6 @@
   </div>
 </form>
 
-</body>
-</html>
-
 {{end}}
 
 {{block "extrajs" .}}

--- a/templates/titles/upload-results.go.html
+++ b/templates/titles/upload-results.go.html
@@ -1,25 +1,55 @@
-{{define "all-success"}}
-<h2>{{pluralize "Title" "Titles" (len .Data.Successes)}} Uploaded</h2>
+{{define "successes"}}
 
-{{range .Data.Successes}}
-<div class="card">
-  <div class="card-body">
-    <h5 class="card-title">{{.MARC.Title}} ({{.MARC.LCCN}})<h5>
-    {{if .New}}
-    <p class="card-subtitle marc-new-warning">
-      Note: this title is new to NCA. Please edit it to provide details such as
-      SFTP username, rights statement, etc.
-    </p>
-    {{end}}
+<h3>{{pluralize "upload" "uploads" (len .)}} succeeded:</h3>
+<div class="row mb-3">
+  {{range .}}
+  <div class="col-sm-6">
+    <div class="card mb-3">
+      <div class="card-header">
+        <h4 class="card-title h5">{{.MARC.Title}} ({{.MARC.LCCN}})</h4>
+        {{if .New}}
+        <p class="card-subtitle marc-new-warning">
+          Note: this title is new to NCA. Please edit it to provide details such as
+          SFTP username, rights statement, etc.
+        </p>
+        {{end}}
+      </div>
+      <div class="card-body">
+        <ul>
+          <li>File: <code>{{.Filename}}</code></li>
+          <li><a href="{{.EditTitleURL}}">View / update title in NCA</a></li>
+          <li><a href="{{StagingRootURL}}/lccn/{{.MARC.LCCN}}/">View in ONI (Staging)</a></li>
+          <li><a href="{{ProdRootURL}}/lccn/{{.MARC.LCCN}}/">View in ONI (Production)</a></li>
+        </ul>
+      </div>
+    </div>
   </div>
-  <dl class="list-group list-group-flush">
-    <li class="list-group-item">Filename: {{.Filename}}</li>
-    <li class="list-group-item"><a href="{{.EditTitleURL}}">View / update title in NCA</a></li>
-    <li class="list-group-item"><a href="{{StagingRootURL}}/lccn/{{.MARC.LCCN}}/">View in ONI (Staging)</a></li>
-    <li class="list-group-item"><a href="{{ProdRootURL}}/lccn/{{.MARC.LCCN}}/">View in ONI (Production)</a></li>
-  </dl>
+  {{end}}
 </div>
+
 {{end}}
+
+
+
+{{define "failures"}}
+
+<h3>{{pluralize "upload" "uploads" (len .)}} failed:</h3>
+<div class="row mb-3">
+  {{range .}}
+  <div class="col-sm-6">
+    <div class="card mb-3">
+      <div class="card-header">
+        <h4 class="card-title h5">File: <code>{{.Filename}}</code></h4>
+      </div>
+      <div class="card-body">
+        <div>
+          {{.ErrorMessage}}
+        </div>
+      </div>
+    </div>
+  </div>
+  {{end}}
+</div>
 
 {{end}}
 
@@ -34,11 +64,15 @@ No uploads succeeded
 {{block "content" .}}
 
 {{if not .Data.Failures}}
-  {{template "all-success" .}}
+  <h2>Success</h2>
+  {{template "successes" .Data.Successes}}
 {{else if not .Data.Successes}}
-  {{template "no-success" .}}
+  <h2>Error: no titles created</h2>
+  {{template "failures" .Data.Failures}}
 {{else}}
-  {{template "partial-success" .}}
+  <h2>Partial Success</h2>
+  {{template "failures" .Data.Failures}}
+  {{template "successes" .Data.Successes}}
 {{end}}
 
 {{end}}

--- a/templates/titles/upload-results.go.html
+++ b/templates/titles/upload-results.go.html
@@ -1,0 +1,44 @@
+{{define "all-success"}}
+<h2>{{pluralize "Title" "Titles" (len .Data.Successes)}} Uploaded</h2>
+
+{{range .Data.Successes}}
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">{{.MARC.Title}} ({{.MARC.LCCN}})<h5>
+    {{if .New}}
+    <p class="card-subtitle marc-new-warning">
+      Note: this title is new to NCA. Please edit it to provide details such as
+      SFTP username, rights statement, etc.
+    </p>
+    {{end}}
+  </div>
+  <dl class="list-group list-group-flush">
+    <li class="list-group-item">Filename: {{.Filename}}</li>
+    <li class="list-group-item"><a href="{{.EditTitleURL}}">View / update title in NCA</a></li>
+    <li class="list-group-item"><a href="{{StagingRootURL}}/lccn/{{.MARC.LCCN}}/">View in ONI (Staging)</a></li>
+    <li class="list-group-item"><a href="{{ProdRootURL}}/lccn/{{.MARC.LCCN}}/">View in ONI (Production)</a></li>
+  </dl>
+</div>
+{{end}}
+
+{{end}}
+
+{{define "partial-success"}}
+Some uploads succeeded
+{{end}}
+
+{{define "no-success"}}
+No uploads succeeded
+{{end}}
+
+{{block "content" .}}
+
+{{if not .Data.Failures}}
+  {{template "all-success" .}}
+{{else if not .Data.Successes}}
+  {{template "no-success" .}}
+{{else}}
+  {{template "partial-success" .}}
+{{end}}
+
+{{end}}

--- a/test/README.md
+++ b/test/README.md
@@ -52,18 +52,17 @@ Examples:
 
 ---
 
-*Note*: If you have titles that can't be found on Chronicling America, **you
-also need to provide MARC XML records** in the `sources/marc-xml` directory and
-then run the title loading script, e.g.:
-
-```bash
-cd test
-go run load-marc.go -c ../settings
-cd ..
-```
-
-Without these, batches will fail to load into ONI. The filenames have to end in
+*Note*: If you have titles that can't be found on Chronicling America, or you
+simply don't want to add them to NCA yourself, **you also need to provide MARC
+XML records** in the `sources/marc-xml` directory. The filenames have to end in
 either `.xml` or `.mrk`.
+
+If you don't provide these, you won't be able to queue up batches in NCA
+without manually adding the titles. And if they aren't available on Chronicling
+America, batches will fail to load into ONI. 
+
+You can manually run the `load-marc.go` helper to load these, or use the
+local-dev `prep_for_testing` alias, detailed in "Ingest Sources" below.
 
 ### Want A Subset?
 
@@ -80,14 +79,17 @@ by using `scripts/localdev.sh` in the root of the NCA project. It exposes a
 function, `prep_for_testing`, which does the following:
 
 - Deletes everything in the database
-- Loads seed data from `docker/mysql/nca-seed-data.sql`:
-  - This is a hard-coded filename - it must be *exactly* as written above.
-  - This file is *not* provided - you have to export things yourself or write
-    your own SQL here. The two critical tables for getting data to work are
-    `titles` and `mocs`.
 - Removes all files from your fake newspaper "network mount"
-  (`test/fakemount`).
-- Runs `copy-sources.go` to bring all source files into the fake mount.
+  (`<NCA root>/test/fakemount`, mounted by default in docker containers when
+  using the "Hybrid Developer" approach).
+- Creates test users via `create-test-users.go`: one user is created per
+  distinct NCA role.
+- Seeds the database with two MARC Organization codes (awardees) so that the
+  NCA test data repository (see above) will work out of the box.
+- Runs `copy-sources.go` to bring all source PDFs and TIFFs into `fakemount` in
+  the structure NCA requires.
+- Runs `load-marc.go` to get all titles (from `test/sources/marc-xml`) loaded
+  into NCA as well as both configured ONI instances.
 - Runs the NCA bulk issue queue app to take every born-digital issue and
   prepare it for page renumbering.
   - This is run once per LCCN because of how NCA's bulk issue queue app was

--- a/test/README.md
+++ b/test/README.md
@@ -6,27 +6,27 @@ whole lot of repetitive data entry.
 
 ## Prerequisites
 
-To make this work, you will want to do local development with docker
-"assistance". This means you have docker running the database, the IIIF server,
-and the SFTP server, but your NCA-native apps are compiled locally and run
-directly. You can try to follow along using a different approach, but this
-guide is meant for that use-case since it's the approach we use for quick dev
-work.
+To make this work, you *must* be following the ["Hybrid Dev" approach to
+development][hybrid-dev]. If you don't, the scripts and recipes here will not
+work! This means you have docker running the database, the IIIF server, and the
+SFTP server, but your NCA-native apps are compiled locally and run directly.
 
 You will need some pieces of the local dev script. You can read it and try to
 do things manually, but the easiest approach is simply to source the script
 into bash: `source <NCA root>/scripts/localdev.sh`.
 
+[hybrid-dev]: <https://uoregon-libraries.github.io/newspaper-curation-app/contributing/dev-guide/#hybrid-developer>
+
 ## Source Data
 
 To start, you need source data. We have [a repository of Oregon data][1] for
-this, but it may not be too useful to everybody since you'll have to create
-dummy titles and MARC org codes. But it could be useful to look at or as a
-starting point if you change some directory names to match your actual titles.
+this. It's obviously very Oregon-specific, but it could be useful to look at or
+as a starting point if you change some directory names to match your actual
+titles / awardees.
 
 [1]: <https://github.com/uoregon-libraries/nca-test-data>
 
-All data you want to bring into a test NCA instance will live under
+All issues you want to bring into a test NCA instance will live under
 `sources/scans` or `sources/sftp`. The `scans` dir would be for issues which
 have TIFFs and PDFs, where the TIFF is the record of source and the PDF has the
 OCR data. `sftp` is for born-digital issues which only have PDFs.
@@ -50,12 +50,28 @@ Examples:
   Bohemia Nugget*, using the MARC org code representing "University of Oregon
   Libraries".
 
+---
+
+*Note*: If you have titles that can't be found on Chronicling America, **you
+also need to provide MARC XML records** in the `sources/marc-xml` directory and
+then run the title loading script, e.g.:
+
+```bash
+cd test
+go run load-marc.go -c ../settings
+cd ..
+```
+
+Without these, batches will fail to load into ONI. The filenames have to end in
+either `.xml` or `.mrk`.
+
 ### Want A Subset?
 
-The `test/` directory ignores anything below it beginning with "sources", so if
-you want, you could have a huge list of source issues in something like
-"sources-all", and just copy in a subset of issues when you are testing a
-specific situation. This will make the ingest and curation a lot faster.
+This directory's `.gitignore` is set up so that anything beginning with
+"sources" will be ignored from any git commands. If you want, you could have a
+huge list of source issues in something like "sources-all", and just copy in a
+subset of issues when you are testing a specific situation. This can make the
+test runs significantly faster.
 
 ## Ingest Sources
 
@@ -69,9 +85,6 @@ function, `prep_for_testing`, which does the following:
   - This file is *not* provided - you have to export things yourself or write
     your own SQL here. The two critical tables for getting data to work are
     `titles` and `mocs`.
-  - Currently this requires you to do local development for the Go side of
-    things (because that's how I'm doing it) and use docker for the external
-    services (MySQL, IIIF server, and SFTPGo).
 - Removes all files from your fake newspaper "network mount"
   (`test/fakemount`).
 - Runs `copy-sources.go` to bring all source files into the fake mount.

--- a/test/load-marc.go
+++ b/test/load-marc.go
@@ -1,0 +1,89 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/uoregon-libraries/gopkg/fileutil"
+	"github.com/uoregon-libraries/gopkg/logger"
+	"github.com/uoregon-libraries/newspaper-curation-app/internal/openoni"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/cli"
+	"github.com/uoregon-libraries/newspaper-curation-app/src/config"
+)
+
+var conf *config.Config
+
+type _opts struct {
+	cli.BaseOptions
+}
+
+var opts _opts
+var l = logger.New(logger.Debug, false)
+
+func getOpts() {
+	var c = cli.New(&opts)
+	conf = c.GetConf()
+}
+
+func main() {
+	getOpts()
+
+	// Find all *.xml and *.mrk files in the marc-xml dir
+	var wd, err = os.Getwd()
+	if err != nil {
+		l.Fatalf("Cannot get current directory!")
+	}
+	var marcDir = filepath.Join(wd, "sources", "marc-xml")
+
+	var files []string
+	files, err = getFiles(marcDir, ".xml", ".XML", ".mrk", ".MRK")
+	if err != nil {
+		l.Fatalf("Unable to read MARC files in %q: %s", marcDir, err)
+	}
+
+	var stagAgent, prodAgent *openoni.RPC
+	stagAgent, err = openoni.New(conf.StagingAgentConnection)
+	if err != nil {
+		l.Fatalf("Invalid staging agent connection string %q: %s", conf.StagingAgentConnection, err)
+	}
+	prodAgent, err = openoni.New(conf.ProductionAgentConnection)
+	if err != nil {
+		l.Fatalf("Invalid production agent connection string %q: %s", conf.ProductionAgentConnection, err)
+	}
+
+	var data []byte
+	for _, f := range files {
+		l.Infof("Loading title from MARC in %q", f)
+		data, err = os.ReadFile(f)
+		if err != nil {
+			l.Fatalf("Unable to read file %q: %s", f, err)
+		}
+
+		_, err = stagAgent.LoadTitle(data)
+		if err != nil {
+			l.Fatalf("Unable to load %q to staging: %s", f, err)
+		}
+		_, err = prodAgent.LoadTitle(data)
+		if err != nil {
+			l.Fatalf("Unable to load %q to production: %s", f, err)
+		}
+		l.Infof("Successfully loaded %q to staging and production", f)
+	}
+}
+
+func getFiles(dir string, exts ...string) ([]string, error) {
+	var fileList, err = fileutil.FindIf(dir, func(i os.FileInfo) bool {
+		for _, ext := range exts {
+			if filepath.Ext(i.Name()) == ext {
+				return true
+			}
+		}
+		return false
+	})
+
+	sort.Strings(fileList)
+	return fileList, err
+}

--- a/test/recipes/testlib.sh
+++ b/test/recipes/testlib.sh
@@ -20,9 +20,18 @@ build_and_clean() {
   rm -f workers.log
 }
 
+load_titles() {
+  cd test
+  go run load-marc.go -c ../settings
+  cd ..
+}
+
 prep_and_backup_00() {
   if [[ ! -d ./backup/00-$name ]]; then
     prep_for_testing
+    docker compose up -d oni-agent-staging oni-agent-prod
+    sleep 1
+    load_titles
 
     # Save state using the "name" variable from above
     ./manage backup 00-$name


### PR DESCRIPTION
Closes #357 

Adds title uploads via MARC XML, which gets ingested into NCA and then sent to ONI.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>