### PR TITLE
Fix localdev.sh's solr breakage

### DIFF
--- a/changelogs/2024-12-23-localdev-solr-fix.md
+++ b/changelogs/2024-12-23-localdev-solr-fix.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `scripts/localdev.sh` no longer loads titles into ONI instances immediately
+  after database setup is done. This was sometimes happening faster than ONI
+  could initialize the Solr schema, which caused wonderful silent Solr problems
+  that would prevent loading batches, but with error messages that didn't
+  really explain the root problem well.

--- a/scripts/localdev.sh
+++ b/scripts/localdev.sh
@@ -86,6 +86,19 @@ load_seed_data() {
     ('oru','University of Oregon Libraries; Eugene, OR'),
     ('hoodriverlibrary','Hood River County Library District; Hood River, OR');"
   pushd .
+
+  # I hate this hack, but it seems loading titles into ONI interacts with Solr
+  # in some disastrous way if ONI hasn't finished setting up the Solr schema
+  # bits, and currently we don't have a way to do a simple "are you
+  # initialized?" query for ONI
+  echo -n "Waiting for ONI"
+  while true; do
+    echo -n "."
+    docker compose exec oni-staging curl -s --head localhost >/dev/null && break
+    sleep 1
+  done
+  echo
+
   cd ./test
   go run load-marc.go -c ../settings
   popd

--- a/scripts/localdev.sh
+++ b/scripts/localdev.sh
@@ -91,10 +91,17 @@ load_seed_data() {
   # in some disastrous way if ONI hasn't finished setting up the Solr schema
   # bits, and currently we don't have a way to do a simple "are you
   # initialized?" query for ONI
-  echo -n "Waiting for ONI"
+  echo -n "Waiting for ONI staging"
   while true; do
     echo -n "."
     docker compose exec oni-staging curl -s --head localhost >/dev/null && break
+    sleep 1
+  done
+  echo
+  echo -n "Waiting for ONI production"
+  while true; do
+    echo -n "."
+    docker compose exec oni-prod curl -s --head localhost >/dev/null && break
     sleep 1
   done
   echo

--- a/test/recipes/testlib.sh
+++ b/test/recipes/testlib.sh
@@ -2,6 +2,7 @@
 set -eu
 
 wait_db() {
+  start_docker_services
   set +e && wait_for_database && set -e
 }
 


### PR DESCRIPTION
Fixes the localdev setup which immediately loaded titles to ONI after the NCA database was ready. This sometimes hosed Solr since it takes a bit for the ONI containers to initialize their side of things, Solr in particular.

This has no production impact as it only broke local dev.