### PR TITLE
Check errors on parsing MARC XML

### DIFF
--- a/src/cmd/server/internal/titlehandler/marc.go
+++ b/src/cmd/server/internal/titlehandler/marc.go
@@ -56,6 +56,10 @@ func lookupMARC(t *Title, marcLoc string) error {
 
 	var m *marc.MARC
 	m, err = marc.ParseXML(reader)
+	if err != nil {
+		return fmt.Errorf("parsing MARC XML: %w", err)
+	}
+
 	t.MARCTitle = m.Title()
 	t.MARCLocation = m.Location()
 	t.LangCode3 = m.Language()


### PR DESCRIPTION
Critical hotfix: pulling invalid / missing MARC XMLs was busted in a way that crashed the server.