### PR TITLE
Fix/external job resilience

### DIFF
--- a/changelogs/2025-01-31-external-job-resilience.md
+++ b/changelogs/2025-01-31-external-job-resilience.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- Jobs involving external services (ONI Agent) are now set up such that the
+  whole group is retried when something goes wrong. This fixes the "wait for
+  ONI" loop when an ONI Agent job fails:
+  - NCA queues a job that will call out to ONI Agent (e.g., load a batch). This
+    job almost always succeeds because it's just asking the agent to put
+    something in *its* job queue.
+  - NCA queues a job to check ONI Agent for success. This fails if the Agent's
+    job failed.
+  - On failure of any job, NCA retries that job. In this case, it *only*
+    retries the "check for success" job. Which just rechecks a failed Agent
+    job.
+  - The "check for success" job fails, and a retry is queued. But no matter how
+    many times you ask "did you succeed?", if you don't start a new external
+    job, the answer is still "no".
+- ONI Agent's magic "job is redundant and not queued" response is now handled
+  properly as a success. (e.g., queueing a batch to be loaded when it's already
+  been loaded successfully)
+
+### Added
+
+- New test recipe script for helping guide a dev in testing a fake Solr outage

--- a/src/cmd/migrate-database/_sql/20250124124500_entwine_jobs.sql
+++ b/src/cmd/migrate-database/_sql/20250124124500_entwine_jobs.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE `jobs` ADD COLUMN `entwine_id` BIGINT DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE `jobs` DROP COLUMN `entwine_id`;

--- a/src/jobs/api_jobs.go
+++ b/src/jobs/api_jobs.go
@@ -168,10 +168,10 @@ func (j *ONIWaitForJob) Process(c *config.Config) ProcessResponse {
 		return PRTryLater
 	case openoni.JobStatusFailStart:
 		j.Logger.Errorf("ONI Agent job %d failed to start", jobID)
-		return PRFatal
+		return PRFailure
 	case openoni.JobStatusFailed:
 		j.Logger.Errorf("ONI Agent job %d failed to complete", jobID)
-		return PRFatal
+		return PRFailure
 	case openoni.JobStatusSuccessful:
 		j.Logger.Infof("ONI Agent reports job completed successfully")
 		return PRSuccess

--- a/src/jobs/api_jobs.go
+++ b/src/jobs/api_jobs.go
@@ -48,8 +48,8 @@ func (j *BatchJob) queueAgentJob(name string, fn batchJobFunc) ProcessResponse {
 	// need to be scrutinized
 	j.DBBatch.ONIAgentJobID = jobid
 
-	// It's pretty critical that we save the batch data and queue a "wait for
-	// ONI" job since the ONI job was successfully created
+	// It's pretty critical that we save the batch data since the ONI job was
+	// successfully created
 	err = j.runCritical(func() error {
 		var msg = fmt.Sprintf("Sent ONI Agent the %s command", name)
 		var err = j.DBBatch.Save(models.ActionTypeInternalProcess, models.SystemUser.ID, msg)

--- a/src/jobs/api_jobs.go
+++ b/src/jobs/api_jobs.go
@@ -134,6 +134,10 @@ type ONIWaitForJob struct {
 // been set in the ID arg
 func (j *ONIWaitForJob) Valid() bool {
 	var id = j.DBBatch.ONIAgentJobID
+	if id == -1 {
+		j.Logger.Infof("ONIWaitForJob done: Agent reported unnecessary job")
+		return true
+	}
 	if id < 1 {
 		j.Logger.Errorf("ONIWaitForJob created with an invalid id (%d)", id)
 		return false

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -88,7 +88,7 @@ func getJobsForMoveDir(source, destination string, exclusions ...string) []*mode
 // getJobsForONIBatch returns jobs that are either for loading or purging an
 // ONI batch on the given environment, pre-set to be entwined.
 func getJobsForONIBatch(batch *models.Batch, jType models.JobType, env string) []*models.Job {
-	var queue = batch.BuildJob(jType, makeLocArgs(serverTypeStaging))
+	var queue = batch.BuildJob(jType, makeLocArgs(env))
 	var wait = batch.BuildJob(models.JobTypeONIWaitForJob, makeLocArgs(env))
 	models.EntwineJobs([]*models.Job{queue, wait})
 	return []*models.Job{queue, wait}

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -86,10 +86,11 @@ func getJobsForMoveDir(source, destination string, exclusions ...string) []*mode
 }
 
 // getJobsForONIBatch returns jobs that are either for loading or purging an
-// ONI batch on the given environment
+// ONI batch on the given environment, pre-set to be entwined.
 func getJobsForONIBatch(batch *models.Batch, jType models.JobType, env string) []*models.Job {
 	var queue = batch.BuildJob(jType, makeLocArgs(serverTypeStaging))
 	var wait = batch.BuildJob(models.JobTypeONIWaitForJob, makeLocArgs(env))
+	models.EntwineJobs([]*models.Job{queue, wait})
 	return []*models.Job{queue, wait}
 }
 

--- a/src/jobs/queue.go
+++ b/src/jobs/queue.go
@@ -85,6 +85,14 @@ func getJobsForMoveDir(source, destination string, exclusions ...string) []*mode
 	return jobs
 }
 
+// getJobsForONIBatch returns jobs that are either for loading or purging an
+// ONI batch on the given environment
+func getJobsForONIBatch(batch *models.Batch, jType models.JobType, env string) []*models.Job {
+	var queue = batch.BuildJob(jType, makeLocArgs(serverTypeStaging))
+	var wait = batch.BuildJob(models.JobTypeONIWaitForJob, makeLocArgs(env))
+	return []*models.Job{queue, wait}
+}
+
 // QueueSFTPIssueMove queues up an issue move into the workflow area followed
 // by a page-split and then a move to the page review area
 //
@@ -217,13 +225,10 @@ func getJobsForMakeBatch(batch *models.Batch, c *config.Config) []*models.Job {
 	// Finally, the last jobs copy the essential files to the final path so we
 	// can ingest them into staging
 	jobs = append(jobs, getJobsForCopyDir(outDir, liveDir, "*.tif", "*.tiff", "*.TIF", "*.TIFF", "*.tar.bz", "*.tar")...)
-	jobs = append(jobs,
-		batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("copied to live path")),
-		batch.BuildJob(models.JobTypeONILoadBatch, makeLocArgs(serverTypeStaging)),
-		batch.BuildJob(models.JobTypeONIWaitForJob, makeLocArgs(serverTypeStaging)),
-		batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("ingested on staging")),
-		batch.BuildJob(models.JobTypeSetBatchStatus, makeBSArgs(models.BatchStatusQCReady)),
-	)
+	jobs = append(jobs, batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("copied to live path")))
+	jobs = append(jobs, getJobsForONIBatch(batch, models.JobTypeONILoadBatch, serverTypeStaging)...)
+	jobs = append(jobs, batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("ingested on staging")))
+	jobs = append(jobs, batch.BuildJob(models.JobTypeSetBatchStatus, makeBSArgs(models.BatchStatusQCReady)))
 
 	return jobs
 }
@@ -336,11 +341,8 @@ func getJobsForFinalizingFlaggedIssues(batch *models.Batch, flagged []*models.Fl
 	)
 
 	// Next purge the batch from staging
-	jobs = append(jobs,
-		batch.BuildJob(models.JobTypeONIPurgeBatch, makeLocArgs(serverTypeStaging)),
-		batch.BuildJob(models.JobTypeONIWaitForJob, makeLocArgs(serverTypeStaging)),
-		batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("purged batch from staging")),
-	)
+	jobs = append(jobs, getJobsForONIBatch(batch, models.JobTypeONIPurgeBatch, serverTypeStaging)...)
+	jobs = append(jobs, batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("purged batch from staging")))
 
 	// Now we remove issues one at a time so we can easily resume / restart.
 	// Removing an issue means we first remove the METS XML file, and only when
@@ -393,8 +395,7 @@ func QueueBatchGoLive(batch *models.Batch, c *config.Config) error {
 	var jobs []*models.Job
 
 	// First we need jobs to push the batch to production ONI
-	jobs = append(jobs, batch.BuildJob(models.JobTypeONILoadBatch, makeLocArgs(serverTypeProd)))
-	jobs = append(jobs, batch.BuildJob(models.JobTypeONIWaitForJob, makeLocArgs(serverTypeProd)))
+	jobs = append(jobs, getJobsForONIBatch(batch, models.JobTypeONILoadBatch, serverTypeProd)...)
 	jobs = append(jobs, batch.BuildJob(models.JobTypeBatchAction, makeActionArgs("ingested on production")))
 
 	// Then archive-move jobs

--- a/src/jobs/runner.go
+++ b/src/jobs/runner.go
@@ -188,13 +188,12 @@ func (r *Runner) handleFailure(pr Processor) {
 		return
 	}
 
-	var retryJob, err = dbj.FailAndRetry()
+	var err = dbj.FailAndRetry()
 	if err != nil {
 		r.logger.Criticalf("Unable to requeue failed job (job: %d): %s", dbj.ID, err)
 		return
 	}
-	r.logger.Warnf("Failed job %d: retrying via job %d at %s (try #%d)",
-		dbj.ID, retryJob.ID, retryJob.RunAt, retryJob.RetryCount)
+	r.logger.Warnf("Failed job %d: retrying later", dbj.ID)
 }
 
 func (r *Runner) handleTryLater(pr Processor) {

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -508,7 +508,7 @@ func (j *Job) failAndRetryGroup(op *magicsql.Operation) error {
 	}
 
 	// Grab all entwined jobs
-	var sourceJobs, err = findJobs("pipeline_id = ? AND entwine_id = ? ORDER BY sequence", j.PipelineID, j.EntwineID)
+	var sourceJobs, err = findJobs("pipeline_id = ? AND entwine_id = ? AND status <> ? ORDER BY sequence", j.PipelineID, j.EntwineID, JobStatusFailedDone)
 	if err != nil {
 		return fmt.Errorf("getting entwined jobs: %w", err)
 	}

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -398,7 +398,7 @@ func CompleteJob(j *Job) error {
 	// Nothing pending, nothing on hold, nothing in process, nothing failed but
 	// awaiting retry. Time to close the pipeline? For safety, we only close the
 	// pipeline if its only jobs are those which have been completed or closed.
-	n = countJobsOp(op, "pipeline_id = ? AND status NOT IN (?, ?)", JobStatusSuccessful, JobStatusFailedDone)
+	n = countJobsOp(op, "pipeline_id = ? AND status NOT IN (?, ?)", j.PipelineID, JobStatusSuccessful, JobStatusFailedDone)
 	if n == 0 {
 		p.CompletedAt = time.Now()
 		return p.saveOp(op)

--- a/test/recipes/broken-oni-job.sh
+++ b/test/recipes/broken-oni-job.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -eu
+
+# This script's purpose is to just run through an end-to-end test starting from
+# nothing, faking curation, then generating and approving batches. It's a good
+# starting point for building other tests, and an okay test when doing a refactor
+# that may cause unexpected changes.
+
+source test/recipes/testlib.sh
+source scripts/localdev.sh
+
+name=$(get_testname ${1:-})
+build_and_clean
+prep_and_backup_00
+
+if [[ ! -d ./backup/01-$name ]]; then
+  wait_db
+
+  # Wait until DB is up and start workers
+  workonce 2>&1 | tee -a workers.log
+
+  # Wait for jobs to finish
+
+  # Renumber page review PDFs and hack their date
+  cd test
+  ./rename-page-review.sh
+  ./make-older.sh
+  cd ..
+
+  # If necessary, restart workers to make the PDF mover re-read the filesystem quicker
+  workonce 2>&1 | tee -a workers.log
+
+  # Wait for jobs to complete (~10min)
+
+  # Stop workers, save state
+  ./manage backup 01-$name
+else
+  echo "Detected backup 01; skipping processing"
+  if [[ ! -d ./backup/02-$name ]]; then
+    echo "Restoring backup 01"
+    ./manage restore 01-$name
+  fi
+fi
+
+if [[ ! -d ./backup/02-$name ]]; then
+  curate_and_review
+
+  # Stop workers, save state again
+  ./manage backup 02-$name
+else
+  echo "Detected backup 02; skipping processing"
+  if [[ ! -d ./backup/03-$name ]]; then
+    echo "Restoring backup 02"
+    ./manage restore 02-$name
+  fi
+fi
+
+if [[ ! -d ./backup/03-$name ]]; then
+  make bin/run-jobs
+  start_docker_services
+  wait_db
+  ./bin/queue-batches -c ./settings 2>&1 | tee -a queue-batches.log
+
+  echo "Disable Solr in staging, then press [ENTER] continue."
+  read
+
+  echo
+  echo "Ready to continue. DO NOT re-enable Solr until you've seen enough 'oni_wait_for_job'"
+  echo "failures that you're confident in the entwine-retry process."
+  echo
+  echo "Press [ENTER] to start the job runner"
+  read
+
+  # Start workers, wait for jobs to complete (~30sec). Do NOT use the
+  # "workonce" shortcut, as it will restart solr!
+  ./bin/run-jobs -c ./settings -v --exit-when-done watchall
+
+  echo "Verify batches are on ONI staging, approve them in NCA, then press [ENTER] continue"
+  read
+  ./manage backup 03-$name
+else
+  echo "Detected backup 03; skipping processing"
+  if [[ ! -d ./backup/04-$name ]]; then
+    echo "Restoring backup 03"
+    ./manage restore 03-$name
+  fi
+fi
+
+if [[ ! -d ./backup/04-$name ]]; then
+  wait_db
+  run_batch_jobs
+
+  ./manage backup 04-$name
+else
+  echo "Detected backup 04; skipping processing"
+  echo "Restoring backup 04"
+  ./manage restore 04-$name
+fi
+
+wait_db
+go run test/report.go -c ./settings --dir=$(pwd)/test --name=$name
+echo "DONE"


### PR DESCRIPTION
Closes #347 

Adds a new concept to NCA: "entwined jobs". When entwined, all jobs are retried as a group when any of them fails.

Probably could have just called them "dependent" or something, but I needed a word that conveyed the fact that this is a rather unusual use-case we've got, and it needs an unusual solution.

## Normal contributors

I have done all of the following:

- [ ] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>