### PR TITLE
Feature/always entwined forevermore

### DIFF
--- a/changelogs/2025-02-20-entwine-fix.md
+++ b/changelogs/2025-02-20-entwine-fix.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Entwined jobs always retry together, even when one fails fatally and is
+  manually restarted (via `run-jobs requeue`)

--- a/src/cmd/run-jobs/main.go
+++ b/src/cmd/run-jobs/main.go
@@ -216,7 +216,7 @@ func retryJob(idString string) {
 	}
 
 	logger.Infof("Requeuing job %d", dj.ID)
-	var _, err = models.RenewDeadJob(dj)
+	var err = dj.FailAndRetry()
 	if err != nil {
 		logger.Errorf("Unable to requeue job %d: %s", dj.ID, err)
 	}

--- a/test/recipes/broken-oni-job.sh
+++ b/test/recipes/broken-oni-job.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
-# This script's purpose is to just run through an end-to-end test starting from
-# nothing, faking curation, then generating and approving batches. It's a good
-# starting point for building other tests, and an okay test when doing a refactor
-# that may cause unexpected changes.
+# This script's purpose is to just run through an end-to-end test, but guiding
+# the tester to deliberately break ONI to test NCA's handling of external job
+# failures (entwined job retry / restart).
 
 source test/recipes/testlib.sh
 source scripts/localdev.sh


### PR DESCRIPTION
Closes #387 

Combines the logic needed for retrying a temporarily failed job with that for restarting a fatally failed job.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>
