### PR TITLE
Fix `manage backup` when volumes aren't created

### DIFF
--- a/manage
+++ b/manage
@@ -19,6 +19,10 @@ dcup() {
 }
 
 backup() {
+  # This "create" usually won't matter, but it ensures all volumes have been
+  # created so we don't get errors trying to back them up
+  docker compose create
+
   dir=$(realpath $1)
   mkdir -p $dir
 
@@ -60,10 +64,6 @@ load_seed_data() {
 
 restore() {
   nuke
-
-  # This "create" usually won't matter, but it ensures all volumes have been
-  # created so we don't get errors trying to back them up
-  docker compose create
 
   dir="$1"
   echo "Restoring from $dir"


### PR DESCRIPTION
I thought I finally got all this dealt with a bit ago, but here we are. I put the friggin' volume creation in the wrong place.

This is a dev-only change.