### PR TITLE
Feature/refactor core finder

### DIFF
--- a/src/models/core_finder.go
+++ b/src/models/core_finder.go
@@ -48,6 +48,15 @@ func (f *coreFinder[T]) Limit(limit int) T {
 	return f.outer
 }
 
+// OrderBy sets an order for this finder.
+//
+// TODO: This currently requires a raw SQL order string which ties business
+// logic and DB schema too tightly. Not sure the best way to address this.
+func (f *coreFinder[T]) OrderBy(order string) T {
+	f.ord = order
+	return f.outer
+}
+
 // selector modifies the finder's internal magicsql.Select object based on the
 // finder's state (conditions, limit, order).
 func (f *coreFinder[T]) selector() magicsql.Select {

--- a/src/models/core_finder_test.go
+++ b/src/models/core_finder_test.go
@@ -18,7 +18,9 @@ type mockModel struct {
 func TestCoreFinder(t *testing.T) {
 	dbi.DB = &magicsql.DB{}
 	t.Run("newCoreFinder", func(t *testing.T) {
-		var cf = newCoreFinder("mocks", &mockModel{})
+		// We pass nil for the outer argument as it's not used in the parts being
+		// tested here
+		var cf = newCoreFinder[any](nil, "mocks", &mockModel{})
 
 		if cf.conditions == nil {
 			t.Errorf("conditions should be initialized, but was nil")
@@ -91,7 +93,8 @@ func TestCoreFinder(t *testing.T) {
 
 		for name, tc := range tests {
 			t.Run(name, func(t *testing.T) {
-				var cf = newCoreFinder("mocks", &mockModel{})
+				// We pass nil for the outer argument - see above explanation
+				var cf = newCoreFinder[any](nil, "mocks", &mockModel{})
 				cf.conditions = tc.conditions
 				cf.lim = tc.limit
 				cf.ord = tc.order

--- a/src/models/issue_finder.go
+++ b/src/models/issue_finder.go
@@ -110,8 +110,3 @@ func (f *IssueFinder) Fetch() ([]*Issue, error) {
 	}
 	return list, err
 }
-
-// Count returns the number of records this query would return
-func (f *IssueFinder) Count() (uint64, error) {
-	return f.coreFinder.Count()
-}

--- a/src/models/issue_finder.go
+++ b/src/models/issue_finder.go
@@ -7,17 +7,18 @@ import (
 )
 
 // IssueFinder is a pseudo-DSL for easily creating queries without needing to
-// know the underlying table structure
+// know the underlying table structure.
 type IssueFinder struct {
-	*coreFinder
+	*coreFinder[*IssueFinder]
 }
 
 // Issues returns an IssueFinder: a scoped object for simple filtering of the
-// issues table with a very narrow DSL
+// issues table with a very narrow DSL.
 func Issues() *IssueFinder {
-	var f = newCoreFinder("issues", &Issue{})
+	var f = &IssueFinder{}
+	f.coreFinder = newCoreFinder(f, "issues", &Issue{})
 	f.conditions["ignored = ?"] = false
-	return &IssueFinder{coreFinder: f}
+	return f
 }
 
 // LCCN returns a scope for finding issues with a particular title
@@ -88,12 +89,6 @@ func (f *IssueFinder) Available() *IssueFinder {
 // be reviewed by a given logged-in user.
 func (f *IssueFinder) NotCuratedBy(userID int64) *IssueFinder {
 	f.conditions["metadata_entry_user_id <> ?"] = userID
-	return f
-}
-
-// Limit sets the max issues to return
-func (f *IssueFinder) Limit(limit int) *IssueFinder {
-	f.lim = limit
 	return f
 }
 

--- a/src/models/issue_finder.go
+++ b/src/models/issue_finder.go
@@ -92,15 +92,6 @@ func (f *IssueFinder) NotCuratedBy(userID int64) *IssueFinder {
 	return f
 }
 
-// OrderBy sets an order for this finder.
-//
-// TODO: This currently requires a raw SQL order string which ties business
-// logic and DB schema too tightly. Not sure the best way to address this.
-func (f *IssueFinder) OrderBy(order string) *IssueFinder {
-	f.ord = order
-	return f
-}
-
 // Fetch returns all issues this scoped finder represents
 func (f *IssueFinder) Fetch() ([]*Issue, error) {
 	var list []*Issue


### PR DESCRIPTION
Refactors the core finder to leverage generics to allow chaining methods even from `coreFinder`, reducing duplicated code.

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>