### PR TITLE
docker: pin to ONI 1.1.2

### DIFF
--- a/docker/Dockerfile-oni
+++ b/docker/Dockerfile-oni
@@ -32,7 +32,7 @@ RUN a2dissite 000-default.conf
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 WORKDIR /opt/openoni
-RUN git clone https://github.com/open-oni/open-oni.git -b v1.1.1 --depth 1 .
+RUN git clone https://github.com/open-oni/open-oni.git -b v1.1.2 --depth 1 .
 
 RUN cp docker/entrypoint.sh /
 RUN chmod u+x /entrypoint.sh


### PR DESCRIPTION
This is required to get ONI building in docker again, due to some upstream change with pip or setuptools or something. No tests or documentation as this is strictly a dev fix, and makes things work the way they had been working up until recently.