### PR TITLE
Feature/duration math

### DIFF
--- a/src/duration/duration_test.go
+++ b/src/duration/duration_test.go
@@ -159,109 +159,99 @@ func TestInvalidFormats(t *testing.T) {
 }
 
 func TestRFC3339(t *testing.T) {
-	var tests = []struct {
+	var tests = map[string]struct {
 		d        Duration
 		expected string
 	}{
-		{Duration{}, "P0D"},
-		{Duration{Years: 1, Weeks: 5}, "P1Y35D"},
-		{Duration{Months: 1}, "P1M"},
-		{Duration{Years: 4, Months: 5, Days: 8, Weeks: 3}, "P4Y5M29D"},
-		{Duration{Weeks: 3}, "P3W"},
+		"Zero":         {Duration{}, "P0D"},
+		"YearsWeeks":   {Duration{Years: 1, Weeks: 5}, "P1Y35D"},
+		"Months":       {Duration{Months: 1}, "P1M"},
+		"Complex":      {Duration{Years: 4, Months: 5, Days: 8, Weeks: 3}, "P4Y5M29D"},
+		"WeeksOnlyISO": {Duration{Weeks: 3}, "P3W"},
 	}
 
-	for _, test := range tests {
-		if test.d.RFC3339() != test.expected {
-			t.Errorf("Expected %#v to be normalized to %q, but got %q", test.d, test.expected, test.d.RFC3339())
-		}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got = tc.d.RFC3339()
+			if got != tc.expected {
+				t.Errorf("Expected %#v to be normalized to %q, but got %q", tc.d, tc.expected, got)
+			}
+		})
 	}
 }
 
 func TestAddDate(t *testing.T) {
-	tests := []struct {
-		name     string
+	tests := map[string]struct {
 		start    time.Time
 		years    int
 		months   int
 		days     int
 		expected time.Time
 	}{
-		{
-			name:     "Jan31 plus 1 month caps at Feb 28th",
+		"Jan31 plus 1 month caps at Feb 28th": {
 			start:    time.Date(2023, time.January, 31, 12, 30, 0, 0, time.UTC),
 			months:   1,
 			expected: time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Jan31 plus 1 month on a leap year caps at Feb 29th",
+		"Jan31 plus 1 month on a leap year caps at Feb 29th": {
 			start:    time.Date(2024, time.January, 31, 12, 30, 0, 0, time.UTC),
 			months:   1,
 			expected: time.Date(2024, time.February, 29, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Mar31 minus 1 month caps at Feb 28th",
+		"Mar31 minus 1 month caps at Feb 28th": {
 			start:    time.Date(2023, time.March, 31, 12, 30, 0, 0, time.UTC),
 			months:   -1,
 			expected: time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Mar31 minus 1 month leap year caps at Feb 29th",
+		"Mar31 minus 1 month leap year caps at Feb 29th": {
 			start:    time.Date(2024, time.March, 31, 12, 30, 0, 0, time.UTC),
 			months:   -1,
 			expected: time.Date(2024, time.February, 29, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "May31 plus 1 month",
+		"May31 plus 1 month": {
 			start:    time.Date(2023, time.May, 31, 12, 30, 0, 0, time.UTC),
 			months:   1,
 			expected: time.Date(2023, time.June, 30, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Feb29 minus 1 year",
+		"Feb29 minus 1 year": {
 			start:    time.Date(2024, time.February, 29, 12, 30, 0, 0, time.UTC),
 			years:    -1,
 			expected: time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Feb28 plus 1 year leap year",
+		"Feb28 plus 1 year leap year": {
 			start:    time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
 			years:    1,
 			expected: time.Date(2024, time.February, 28, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Jan31 plus 1 month plus 5 days",
+		"Jan31 plus 1 month plus 5 days": {
 			start:    time.Date(2023, time.January, 31, 12, 30, 0, 0, time.UTC),
 			months:   1,
 			days:     5,
 			expected: time.Date(2023, time.March, 5, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Zero duration doesn't change anything",
+		"Zero duration doesn't change anything": {
 			start:    time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
 			expected: time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Simple day add",
+		"Simple day add": {
 			start:    time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
 			days:     5,
 			expected: time.Date(2023, time.July, 20, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Add 365 days, get exactly one year forward",
+		"Add 365 days, get exactly one year forward": {
 			start:    time.Date(2022, time.July, 15, 12, 30, 0, 0, time.UTC),
 			days:     365,
 			expected: time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
 		},
-		{
-			name:     "Add 365 days to pass a leap day, get +1 year, but -1 day",
+		"Add 365 days to pass a leap day, get +1 year, but -1 day": {
 			start:    time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
 			days:     365,
 			expected: time.Date(2024, time.July, 14, 12, 30, 0, 0, time.UTC),
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			got := addDate(tc.start, tc.years, tc.months, tc.days)
 			if !got.Equal(tc.expected) {
 				t.Errorf("addDate(%s, %dy, %dm, %dd): expected %s, but got %s",
@@ -277,24 +267,23 @@ func TestAddToTime(t *testing.T) {
 	var jan31 = time.Date(2023, time.January, 31, 0, 0, 0, 0, time.UTC)
 	var feb29 = time.Date(2024, time.February, 29, 0, 0, 0, 0, time.UTC) // Leap year
 
-	tests := []struct {
-		name      string
+	tests := map[string]struct {
 		startTime time.Time
 		d         Duration
 		expected  time.Time
 	}{
-		{"Zero", jan15, Duration{}, jan15},
-		{"DaysOnly", jan15, Duration{Days: 5}, time.Date(2023, time.January, 20, 0, 0, 0, 0, time.UTC)},
-		{"WeeksOnly", jan15, Duration{Weeks: 2}, time.Date(2023, time.January, 29, 0, 0, 0, 0, time.UTC)},
-		{"MonthsOnly Jan31", jan31, Duration{Months: 1}, time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
-		{"MonthsOnly Jan15", jan15, Duration{Months: 1}, time.Date(2023, time.February, 15, 0, 0, 0, 0, time.UTC)},
-		{"YearsOnly Jan31", jan31, Duration{Years: 2}, time.Date(2025, time.January, 31, 0, 0, 0, 0, time.UTC)},
-		{"LeapYearAdd Feb29", feb29, Duration{Years: 1}, time.Date(2025, time.February, 28, 0, 0, 0, 0, time.UTC)},
-		{"Complex Jan31", jan31, Duration{Years: 1, Months: 1, Weeks: 1, Days: 1}, time.Date(2024, time.March, 8, 0, 0, 0, 0, time.UTC)},
+		"Zero":              {startTime: jan15, d: Duration{}, expected: jan15},
+		"DaysOnly":          {startTime: jan15, d: Duration{Days: 5}, expected: time.Date(2023, time.January, 20, 0, 0, 0, 0, time.UTC)},
+		"WeeksOnly":         {startTime: jan15, d: Duration{Weeks: 2}, expected: time.Date(2023, time.January, 29, 0, 0, 0, 0, time.UTC)},
+		"MonthsOnly Jan31":  {startTime: jan31, d: Duration{Months: 1}, expected: time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		"MonthsOnly Jan15":  {startTime: jan15, d: Duration{Months: 1}, expected: time.Date(2023, time.February, 15, 0, 0, 0, 0, time.UTC)},
+		"YearsOnly Jan31":   {startTime: jan31, d: Duration{Years: 2}, expected: time.Date(2025, time.January, 31, 0, 0, 0, 0, time.UTC)},
+		"LeapYearAdd Feb29": {startTime: feb29, d: Duration{Years: 1}, expected: time.Date(2025, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		"Complex Jan31":     {startTime: jan31, d: Duration{Years: 1, Months: 1, Weeks: 1, Days: 1}, expected: time.Date(2024, time.March, 8, 0, 0, 0, 0, time.UTC)},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			var got = tc.d.AddToTime(tc.startTime)
 			if !got.Equal(tc.expected) {
 				t.Errorf("Duration %#v from %s: expected %s, but got %s", tc.d, tc.startTime.Format(time.RFC3339), tc.expected.Format(time.RFC3339), got.Format(time.RFC3339))
@@ -308,24 +297,23 @@ func TestSubtractFromTime(t *testing.T) {
 	var mar15 = time.Date(2023, time.March, 15, 0, 0, 0, 0, time.UTC)
 	var feb29 = time.Date(2024, time.February, 29, 0, 0, 0, 0, time.UTC)
 
-	tests := []struct {
-		name      string
+	tests := map[string]struct {
 		startTime time.Time
 		d         Duration
 		expected  time.Time
 	}{
-		{"Zero", mar15, Duration{}, mar15},
-		{"DaysOnly", mar15, Duration{Days: 5}, time.Date(2023, time.March, 10, 0, 0, 0, 0, time.UTC)},
-		{"WeeksOnly", mar15, Duration{Weeks: 2}, time.Date(2023, time.March, 1, 0, 0, 0, 0, time.UTC)},
-		{"MonthsOnly Mar31", mar31, Duration{Months: 1}, time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
-		{"MonthsOnly Mar15", mar15, Duration{Months: 1}, time.Date(2023, time.February, 15, 0, 0, 0, 0, time.UTC)},
-		{"YearsOnly Mar31", mar31, Duration{Years: 2}, time.Date(2021, time.March, 31, 0, 0, 0, 0, time.UTC)},
-		{"LeapYearSub Feb29", feb29, Duration{Years: 1}, time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
-		{"Complex Mar31", mar31, Duration{Years: 1, Months: 1, Weeks: 1, Days: 1}, time.Date(2022, time.February, 20, 0, 0, 0, 0, time.UTC)},
+		"Zero":              {startTime: mar15, d: Duration{}, expected: mar15},
+		"DaysOnly":          {startTime: mar15, d: Duration{Days: 5}, expected: time.Date(2023, time.March, 10, 0, 0, 0, 0, time.UTC)},
+		"WeeksOnly":         {startTime: mar15, d: Duration{Weeks: 2}, expected: time.Date(2023, time.March, 1, 0, 0, 0, 0, time.UTC)},
+		"MonthsOnly Mar31":  {startTime: mar31, d: Duration{Months: 1}, expected: time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		"MonthsOnly Mar15":  {startTime: mar15, d: Duration{Months: 1}, expected: time.Date(2023, time.February, 15, 0, 0, 0, 0, time.UTC)},
+		"YearsOnly Mar31":   {startTime: mar31, d: Duration{Years: 2}, expected: time.Date(2021, time.March, 31, 0, 0, 0, 0, time.UTC)},
+		"LeapYearSub Feb29": {startTime: feb29, d: Duration{Years: 1}, expected: time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		"Complex Mar31":     {startTime: mar31, d: Duration{Years: 1, Months: 1, Weeks: 1, Days: 1}, expected: time.Date(2022, time.February, 20, 0, 0, 0, 0, time.UTC)},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			var got = tc.d.SubtractFromTime(tc.startTime)
 			if !got.Equal(tc.expected) {
 				t.Errorf("Duration %#v ago from %s: expected %s, but got %s", tc.d, tc.startTime.Format(time.RFC3339), tc.expected.Format(time.RFC3339), got.Format(time.RFC3339))

--- a/src/duration/duration_test.go
+++ b/src/duration/duration_test.go
@@ -1,6 +1,9 @@
 package duration
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestParse(t *testing.T) {
 	var d, err = Parse("1 month 3 years 2 weeks 4 days")
@@ -171,5 +174,162 @@ func TestRFC3339(t *testing.T) {
 		if test.d.RFC3339() != test.expected {
 			t.Errorf("Expected %#v to be normalized to %q, but got %q", test.d, test.expected, test.d.RFC3339())
 		}
+	}
+}
+
+func TestAddDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		start    time.Time
+		years    int
+		months   int
+		days     int
+		expected time.Time
+	}{
+		{
+			name:     "Jan31 plus 1 month caps at Feb 28th",
+			start:    time.Date(2023, time.January, 31, 12, 30, 0, 0, time.UTC),
+			months:   1,
+			expected: time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Jan31 plus 1 month on a leap year caps at Feb 29th",
+			start:    time.Date(2024, time.January, 31, 12, 30, 0, 0, time.UTC),
+			months:   1,
+			expected: time.Date(2024, time.February, 29, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Mar31 minus 1 month caps at Feb 28th",
+			start:    time.Date(2023, time.March, 31, 12, 30, 0, 0, time.UTC),
+			months:   -1,
+			expected: time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Mar31 minus 1 month leap year caps at Feb 29th",
+			start:    time.Date(2024, time.March, 31, 12, 30, 0, 0, time.UTC),
+			months:   -1,
+			expected: time.Date(2024, time.February, 29, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "May31 plus 1 month",
+			start:    time.Date(2023, time.May, 31, 12, 30, 0, 0, time.UTC),
+			months:   1,
+			expected: time.Date(2023, time.June, 30, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Feb29 minus 1 year",
+			start:    time.Date(2024, time.February, 29, 12, 30, 0, 0, time.UTC),
+			years:    -1,
+			expected: time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Feb28 plus 1 year leap year",
+			start:    time.Date(2023, time.February, 28, 12, 30, 0, 0, time.UTC),
+			years:    1,
+			expected: time.Date(2024, time.February, 28, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Jan31 plus 1 month plus 5 days",
+			start:    time.Date(2023, time.January, 31, 12, 30, 0, 0, time.UTC),
+			months:   1,
+			days:     5,
+			expected: time.Date(2023, time.March, 5, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Zero duration doesn't change anything",
+			start:    time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
+			expected: time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Simple day add",
+			start:    time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
+			days:     5,
+			expected: time.Date(2023, time.July, 20, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Add 365 days, get exactly one year forward",
+			start:    time.Date(2022, time.July, 15, 12, 30, 0, 0, time.UTC),
+			days:     365,
+			expected: time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Add 365 days to pass a leap day, get +1 year, but -1 day",
+			start:    time.Date(2023, time.July, 15, 12, 30, 0, 0, time.UTC),
+			days:     365,
+			expected: time.Date(2024, time.July, 14, 12, 30, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := addDate(tc.start, tc.years, tc.months, tc.days)
+			if !got.Equal(tc.expected) {
+				t.Errorf("addDate(%s, %dy, %dm, %dd): expected %s, but got %s",
+					tc.start.Format(time.RFC3339), tc.years, tc.months, tc.days,
+					tc.expected.Format(time.RFC3339), got.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+func TestAddToTime(t *testing.T) {
+	var jan15 = time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC)
+	var jan31 = time.Date(2023, time.January, 31, 0, 0, 0, 0, time.UTC)
+	var feb29 = time.Date(2024, time.February, 29, 0, 0, 0, 0, time.UTC) // Leap year
+
+	tests := []struct {
+		name      string
+		startTime time.Time
+		d         Duration
+		expected  time.Time
+	}{
+		{"Zero", jan15, Duration{}, jan15},
+		{"DaysOnly", jan15, Duration{Days: 5}, time.Date(2023, time.January, 20, 0, 0, 0, 0, time.UTC)},
+		{"WeeksOnly", jan15, Duration{Weeks: 2}, time.Date(2023, time.January, 29, 0, 0, 0, 0, time.UTC)},
+		{"MonthsOnly Jan31", jan31, Duration{Months: 1}, time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		{"MonthsOnly Jan15", jan15, Duration{Months: 1}, time.Date(2023, time.February, 15, 0, 0, 0, 0, time.UTC)},
+		{"YearsOnly Jan31", jan31, Duration{Years: 2}, time.Date(2025, time.January, 31, 0, 0, 0, 0, time.UTC)},
+		{"LeapYearAdd Feb29", feb29, Duration{Years: 1}, time.Date(2025, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		{"Complex Jan31", jan31, Duration{Years: 1, Months: 1, Weeks: 1, Days: 1}, time.Date(2024, time.March, 8, 0, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got = tc.d.AddToTime(tc.startTime)
+			if !got.Equal(tc.expected) {
+				t.Errorf("Duration %#v from %s: expected %s, but got %s", tc.d, tc.startTime.Format(time.RFC3339), tc.expected.Format(time.RFC3339), got.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+func TestSubtractFromTime(t *testing.T) {
+	var mar31 = time.Date(2023, time.March, 31, 0, 0, 0, 0, time.UTC)
+	var mar15 = time.Date(2023, time.March, 15, 0, 0, 0, 0, time.UTC)
+	var feb29 = time.Date(2024, time.February, 29, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		startTime time.Time
+		d         Duration
+		expected  time.Time
+	}{
+		{"Zero", mar15, Duration{}, mar15},
+		{"DaysOnly", mar15, Duration{Days: 5}, time.Date(2023, time.March, 10, 0, 0, 0, 0, time.UTC)},
+		{"WeeksOnly", mar15, Duration{Weeks: 2}, time.Date(2023, time.March, 1, 0, 0, 0, 0, time.UTC)},
+		{"MonthsOnly Mar31", mar31, Duration{Months: 1}, time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		{"MonthsOnly Mar15", mar15, Duration{Months: 1}, time.Date(2023, time.February, 15, 0, 0, 0, 0, time.UTC)},
+		{"YearsOnly Mar31", mar31, Duration{Years: 2}, time.Date(2021, time.March, 31, 0, 0, 0, 0, time.UTC)},
+		{"LeapYearSub Feb29", feb29, Duration{Years: 1}, time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC)},
+		{"Complex Mar31", mar31, Duration{Years: 1, Months: 1, Weeks: 1, Days: 1}, time.Date(2022, time.February, 20, 0, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got = tc.d.SubtractFromTime(tc.startTime)
+			if !got.Equal(tc.expected) {
+				t.Errorf("Duration %#v ago from %s: expected %s, but got %s", tc.d, tc.startTime.Format(time.RFC3339), tc.expected.Format(time.RFC3339), got.Format(time.RFC3339))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adds code to make more intuitive date/duration math. e.g., adding one month to January 30th does *not* result in a March date, but "caps" the date to the end of February.

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [ ] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [ ] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>

## Release deployer

I have done all of the following:

- [ ] Put the contents of `changelogs/*` into `CHANGELOG.md`, rewording as
  necessary
- [ ] Delete `changelogs/*` (not the template of course)
- [ ] Set an appropriate version number in the changelog per semantic
  versioning specs
- [ ] Compiled the hugo documentation and verified very carefully that it is
  correctly generated
- [ ] Tested the code carefully, thoroughly, meticulously, and lovingly. It is
  production-ready.

Once this merges, *I swear on all I hold dear* not to forget any of the
post-deploy steps. I will set up a reminder in Outlook, gmail, via some smart
device, etc.

- [ ] Create and push a tag
- [ ] Create a github release from aforementioned tag, describing the changes
  briefly and linking to the full changelog.
