### PR TITLE
docker: fix oni agent version

### DIFF
--- a/docker/Dockerfile-oni
+++ b/docker/Dockerfile-oni
@@ -59,7 +59,7 @@ ENTRYPOINT /entrypoint.sh
 
 FROM golang:1 AS agent-build
 WORKDIR /app
-RUN git clone https://github.com/open-oni/oni-agent.git -b v1.8.0-rc1 --depth 1 .
+RUN git clone https://github.com/open-oni/oni-agent.git -b v1.8.0 --depth 1 .
 RUN make
 
 

--- a/hugo/content/setup/installation.md
+++ b/hugo/content/setup/installation.md
@@ -24,7 +24,7 @@ Manual installation has several prerequisites:
   [RAIS](https://github.com/uoregon-libraries/rais-image-server))
 - Apache/nginx for authentication as well as proxying to NCA and the IIIF server
 - Two running [Open ONI][oni] applications: staging and production.
-- An [ONI Agent][agent] (at least v1.7.0) must be set up for each ONI instance
+- An [ONI Agent][agent] (at least v1.8.0) must be set up for each ONI instance
   in order to automate some of the functionality from NCA to ONI. The NCA
   server needs to be able to connect to the ONI Agent, but the agent's ports
   should not be open to any other traffic.


### PR DESCRIPTION
Fix from previous PR: forgot to make a final ONI Agent version and then pin NCA to it, and forgot to update required ONI Agent version in install documentation.

No production impact, so no tests / changelog.