### PR TITLE
Add `-dAutoRotatePages=/None` to GhostScript args

### DIFF
--- a/changelogs/2025-09-23-page-rotation.md
+++ b/changelogs/2025-09-23-page-rotation.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- When pre-processing PDFs, pages should no longer occasionally auto-rotate. We
+  noticed this issue very rarely, so it wasn't something we even realized NCA
+  was doing, and we're still not entirely sure why. GhostScript simply has been
+  deciding to rotate some pages. Well... *no more*! We hope.

--- a/src/jobs/pagesplit.go
+++ b/src/jobs/pagesplit.go
@@ -107,7 +107,7 @@ func (ps *PageSplit) combinePDF() (ok bool) {
 	var args = []string{
 		"-sDEVICE=pdfwrite", "-dCompatibilityLevel=1.6", "-dPDFSETTINGS=/default",
 		"-dNOPAUSE", "-dQUIET", "-dBATCH", "-dDetectDuplicateImages",
-		"-dCompressFonts=true", "-r150", "-sOutputFile=" + ps.CombinedFile,
+		"-dCompressFonts=true", "-r150", "-dAutoRotatePages=/None", "-sOutputFile=" + ps.CombinedFile,
 	}
 	for _, fi := range fileinfos {
 		args = append(args, filepath.Join(ps.DBIssue.Location, fi.Name()))


### PR DESCRIPTION
Closes #432

This appears to fix at least one case of pages "randomly" being rotated

## Normal contributors

I have done all of the following:

- [x] Fixes and new features have unit tests where applicable
- [x] A new changelog has been created in `changelogs/` (based on
  [`changelogs/template.md`][1])
- [x] Documentation has been updated as necessary (`hugo/content/`)

[1]: <https://github.com/uoregon-libraries/newspaper-curation-app/blob/main/changelogs/template.md>